### PR TITLE
Add test custom command

### DIFF
--- a/cmd/custom.go
+++ b/cmd/custom.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/strangelove-ventures/ibc-test-framework/ibc"
+	"golang.org/x/sync/errgroup"
+)
+
+// customCmd represents the custom command
+var customCmd = &cobra.Command{
+	Use:   "custom",
+	Short: "Run with custom chain configurations",
+	Long: `This command allows you to provide all of the possible configuration parameters
+for spinning up the source and destination chains
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		flags := cmd.Flags()
+		relayerImplementationString, _ := flags.GetString("relayer")
+		testCasesString := args[0]
+
+		relayerImplementation := parseRelayerImplementation(relayerImplementationString)
+
+		srcType, _ := flags.GetString("src-type")
+		dstType, _ := flags.GetString("dst-type")
+
+		// only cosmos chains supported for now
+		switch srcType {
+		case "cosmos":
+			break
+		default:
+			panic(fmt.Sprintf("chain type not supported: %s", srcType))
+		}
+
+		switch dstType {
+		case "cosmos":
+			break
+		default:
+			panic(fmt.Sprintf("chain type not supported: %s", dstType))
+		}
+
+		srcVals, _ := flags.GetInt("src-vals")
+		dstVals, _ := flags.GetInt("dst-vals")
+
+		srcChainID, _ := flags.GetString("src-chain-id")
+		dstChainID, _ := flags.GetString("dst-chain-id")
+
+		srcName, _ := flags.GetString("src-name")
+		dstName, _ := flags.GetString("dst-name")
+
+		srcImage, _ := flags.GetString("src-image")
+		dstImage, _ := flags.GetString("dst-image")
+
+		srcVersion, _ := flags.GetString("src-version")
+		dstVersion, _ := flags.GetString("dst-version")
+
+		srcBinary, _ := flags.GetString("src-binary")
+		dstBinary, _ := flags.GetString("dst-binary")
+
+		srcBech32Prefix, _ := flags.GetString("src-bech32")
+		dstBech32Prefix, _ := flags.GetString("dst-bech32")
+
+		srcDenom, _ := flags.GetString("src-denom")
+		dstDenom, _ := flags.GetString("dst-denom")
+
+		srcGasPrices, _ := flags.GetString("src-gas-prices")
+		dstGasPrices, _ := flags.GetString("dst-gas-prices")
+
+		srcGasAdjustment, _ := flags.GetFloat64("src-gas-adjustment")
+		dstGasAdjustment, _ := flags.GetFloat64("dst-gas-adjustment")
+
+		srcTrustingPeriod, _ := flags.GetString("src-trusting-period")
+		dstTrustingPeriod, _ := flags.GetString("dst-trusting-period")
+
+		parallel, _ := flags.GetBool("parallel")
+
+		srcChainCfg := ibc.NewCosmosChainConfig(srcName, srcImage, srcBinary, srcBech32Prefix, srcDenom, srcGasPrices, srcGasAdjustment, srcTrustingPeriod)
+		dstChainCfg := ibc.NewCosmosChainConfig(dstName, dstImage, dstBinary, dstBech32Prefix, dstDenom, dstGasPrices, dstGasAdjustment, dstTrustingPeriod)
+
+		srcChainCfg.ChainID = srcChainID
+		dstChainCfg.ChainID = dstChainID
+
+		srcChainCfg.Version = srcVersion
+		dstChainCfg.Version = dstVersion
+
+		var testCases []func(testName string, srcChain ibc.Chain, dstChain ibc.Chain, relayerImplementation ibc.RelayerImplementation) error
+
+		for _, testCaseString := range strings.Split(testCasesString, ",") {
+			testCase, err := ibc.GetTestCase(testCaseString)
+			if err != nil {
+				panic(err)
+			}
+			testCases = append(testCases, testCase)
+		}
+
+		if parallel {
+			var eg errgroup.Group
+			for i, testCase := range testCases {
+				testCase := testCase
+				testName := fmt.Sprintf("Test%d", i)
+				srcChain := ibc.NewCosmosChain(testName, srcChainCfg, srcVals, 1)
+				dstChain := ibc.NewCosmosChain(testName, dstChainCfg, dstVals, 1)
+				eg.Go(func() error {
+					return testCase(testName, srcChain, dstChain, relayerImplementation)
+				})
+			}
+			if err := eg.Wait(); err != nil {
+				panic(err)
+			}
+		} else {
+			for i, testCase := range testCases {
+				testName := fmt.Sprintf("Test%d", i)
+				srcChain := ibc.NewCosmosChain(testName, srcChainCfg, srcVals, 1)
+				dstChain := ibc.NewCosmosChain(testName, dstChainCfg, dstVals, 1)
+				if err := testCase(testName, srcChain, dstChain, relayerImplementation); err != nil {
+					panic(err)
+				}
+			}
+		}
+		fmt.Println("PASS")
+	},
+}
+
+func init() {
+	testCmd.AddCommand(customCmd)
+
+	customCmd.Flags().StringP("src-name", "s", "gaia", "Source chain name")
+	customCmd.Flags().String("src-type", "cosmos", "Type of source chain")
+	customCmd.Flags().String("src-bech32", "cosmos", "Bech32 prefix for source chain")
+	customCmd.Flags().String("src-denom", "uatom", "Native denomination for source chain")
+	customCmd.Flags().String("src-gas-prices", "0.01uatom", "Gas prices for source chain")
+	customCmd.Flags().Float64("src-gas-adjustment", 1.3, "Gas adjustment for source chain")
+	customCmd.Flags().String("src-trust", "504h", "Trusting period for source chain ")
+	customCmd.Flags().String("src-image", "ghcr.io/strangelove-ventures/heighliner/gaia", "Docker image for source chain")
+	customCmd.Flags().String("src-version", "v7.0.1", "Docker image version for source chain")
+	customCmd.Flags().String("src-binary", "gaiad", "Binary for source chain")
+	customCmd.Flags().String("src-chain-id", "srcchain-1", "Chain ID to use for the source chain")
+	customCmd.Flags().Int("src-vals", 4, "Number of Validator nodes on source chain")
+
+	customCmd.Flags().StringP("dst-name", "d", "gaia", "Destination chain name")
+	customCmd.Flags().String("dst-type", "cosmos", "Type of destination chain")
+	customCmd.Flags().String("dst-bech32", "cosmos", "Bech32 prefix for destination chain")
+	customCmd.Flags().String("dst-denom", "uatom", "Native denomination for destination chain")
+	customCmd.Flags().String("dst-gas-prices", "0.01uatom", "Gas prices for destination chain")
+	customCmd.Flags().Float64("dst-gas-adjustment", 1.3, "Gas adjustment for destination chain")
+	customCmd.Flags().String("dst-trust", "504h", "Trusting period for destination chain")
+	customCmd.Flags().String("dst-image", "ghcr.io/strangelove-ventures/heighliner/gaia", "Docker image for destination chain")
+	customCmd.Flags().String("dst-version", "v7.0.1", "Docker image version for destination chain")
+	customCmd.Flags().String("dst-binary", "gaiad", "Binary for destination chain")
+	customCmd.Flags().String("dst-chain-id", "dstchain-1", "Chain ID to use for the source chain")
+	customCmd.Flags().Int("dst-vals", 4, "Number of Validator nodes on destination chain")
+
+	customCmd.Flags().StringP("relayer", "r", "rly", "Relayer implementation to use (rly or hermes)")
+	customCmd.Flags().BoolP("parallel", "p", false, "Run tests in parallel")
+
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -67,7 +67,6 @@ ibc-test-framework test --src osmosis:v7.0.4 --dst juno:v2.3.0 --relayer rly Rel
 ibc-test-framework test -s osmosis:v7.0.4 -d juno:v2.3.0 -r rly RelayPacketTest
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("IBC Test Framework")
 		flags := cmd.Flags()
 		srcChainNameVersion, _ := flags.GetString("src")
 		dstChainNameVersion, _ := flags.GetString("dst")

--- a/ibc/cosmos_chain.go
+++ b/ibc/cosmos_chain.go
@@ -36,6 +36,27 @@ type CosmosChain struct {
 }
 
 func NewCosmosChainConfig(name string,
+	dockerImage string,
+	binary string,
+	bech32Prefix string,
+	denom string,
+	gasPrices string,
+	gasAdjustment float64,
+	trustingPeriod string) ChainConfig {
+	return ChainConfig{
+		Type:           "cosmos",
+		Name:           name,
+		Bech32Prefix:   bech32Prefix,
+		Denom:          denom,
+		GasPrices:      gasPrices,
+		GasAdjustment:  gasAdjustment,
+		TrustingPeriod: trustingPeriod,
+		Repository:     dockerImage,
+		Bin:            binary,
+	}
+}
+
+func NewCosmosHeighlinerChainConfig(name string,
 	binary string,
 	bech32Prefix string,
 	denom string,

--- a/ibc/test_chains.go
+++ b/ibc/test_chains.go
@@ -3,9 +3,9 @@ package ibc
 import "fmt"
 
 var chainConfigs = []ChainConfig{
-	NewCosmosChainConfig("gaia", "gaiad", "cosmos", "uatom", "0.01uatom", 1.3, "504h"),
-	NewCosmosChainConfig("osmosis", "osmosisd", "osmo", "uosmo", "0.0uosmo", 1.3, "336h"),
-	NewCosmosChainConfig("juno", "junod", "juno", "ujuno", "0.0025ujuno", 1.3, "672h"),
+	NewCosmosHeighlinerChainConfig("gaia", "gaiad", "cosmos", "uatom", "0.01uatom", 1.3, "504h"),
+	NewCosmosHeighlinerChainConfig("osmosis", "osmosisd", "osmo", "uosmo", "0.0uosmo", 1.3, "336h"),
+	NewCosmosHeighlinerChainConfig("juno", "junod", "juno", "ujuno", "0.0025ujuno", 1.3, "672h"),
 }
 
 var chainConfigMap map[string]ChainConfig


### PR DESCRIPTION
Adds `ibc-test-framework test custom` command, which allows complete customization of chain configurations for running tests.

Resolves #9 