### PR TITLE
Extract ChainFactory interface

### DIFF
--- a/ibc/chainfactory.go
+++ b/ibc/chainfactory.go
@@ -1,0 +1,97 @@
+package ibc
+
+import "fmt"
+
+// ChainFactory describes how to get chains for tests.
+// This type currently supports a Pair method,
+// but it may be expanded to a Triplet method in the future.
+type ChainFactory interface {
+	// Pair returns two chains for IBC.
+	Pair(testName string) (Chain, Chain, error)
+}
+
+// FixedChainFactory implements ChainFactory to return a fixed set of chains.
+// Use NewBuiltinChainFactory to create an instance.
+type BuiltinChainFactory struct {
+	entries []BuiltinChainFactoryEntry
+}
+
+// BuiltinChainFactoryEntry describes a chain to be returned from an instance of BuiltinChainFactory.
+type BuiltinChainFactoryEntry struct {
+	Name          string
+	Version       string
+	ChainID       string
+	NumValidators int
+	NumFullNodes  int
+}
+
+// NewBuiltinChainFactory returns a BuiltinChainFactory that returns chains defined by entries.
+//
+// Currently, NewBuiltinChainFactory will panic if entries is not of length 2.
+// In the future, this method may allow or require entries to have length 3.
+func NewBuiltinChainFactory(entries []BuiltinChainFactoryEntry) *BuiltinChainFactory {
+	if len(entries) != 2 {
+		panic(fmt.Errorf("NewBuiltinChainFactory: received %d entries but required 2", len(entries)))
+	}
+
+	return &BuiltinChainFactory{entries: entries}
+}
+
+// Pair returns two chains to be used in tests that expect exactly two chains.
+func (f *BuiltinChainFactory) Pair(testName string) (Chain, Chain, error) {
+	e := f.entries[0]
+	src, err := GetChain(testName, e.Name, e.Version, e.ChainID, e.NumValidators, e.NumFullNodes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get chain with name %q: %w", e.Name, err)
+	}
+
+	e = f.entries[1]
+	dst, err := GetChain(testName, e.Name, e.Version, e.ChainID, e.NumValidators, e.NumFullNodes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get chain with name %q: %w", e.Name, err)
+	}
+
+	return src, dst, nil
+}
+
+// CustomChainFactory is a ChainFactory that supports returning chains that are defined by ChainConfig values.
+type CustomChainFactory struct {
+	entries []CustomChainFactoryEntry
+}
+
+// CustomChainFactoryEntry describes a chain to be returned by a CustomChainFactory.
+type CustomChainFactoryEntry struct {
+	Type          string
+	Config        ChainConfig
+	NumValidators int
+	NumFullNodes  int
+}
+
+// NewCustomChainFactory returns a CustomChainFactory that returns chains defined by entries.
+//
+// Currently, NewCustomChainFactory will panic if entries is not of length 2.
+// In the future, this method may allow or require entries to have length 3.
+func NewCustomChainFactory(entries []CustomChainFactoryEntry) *CustomChainFactory {
+	if len(entries) != 2 {
+		panic(fmt.Errorf("NewCustomChainFactory: received %d entries but required 2", len(entries)))
+	}
+
+	return &CustomChainFactory{entries: entries}
+}
+
+// Pair returns two chains to be used in tests that expect exactly two chains.
+func (f *CustomChainFactory) Pair(testName string) (Chain, Chain, error) {
+	e := f.entries[0]
+	if e.Type != "cosmos" {
+		return nil, nil, fmt.Errorf("only cosmos type chains are currently supported (got %q)", e.Type)
+	}
+	src := NewCosmosChain(testName, e.Config, e.NumValidators, e.NumFullNodes)
+
+	e = f.entries[1]
+	if e.Type != "cosmos" {
+		return nil, nil, fmt.Errorf("only cosmos type chains are currently supported (got %q)", e.Type)
+	}
+	dst := NewCosmosChain(testName, e.Config, e.NumValidators, e.NumFullNodes)
+
+	return src, dst, nil
+}

--- a/ibc/test_relay.go
+++ b/ibc/test_relay.go
@@ -7,12 +7,17 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 )
 
-func (ibc IBCTestCase) RelayPacketTest(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error {
+func (ibc IBCTestCase) RelayPacketTest(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error {
 	ctx, home, pool, network, cleanup, err := SetupTestRun(testName)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+
+	srcChain, dstChain, err := cf.Pair(testName)
+	if err != nil {
+		return fmt.Errorf("failed to get chain pair: %w", err)
+	}
 
 	// startup both chains and relayer
 	// creates wallets in the relayer for src and dst chain
@@ -171,12 +176,17 @@ func (ibc IBCTestCase) RelayPacketTest(testName string, srcChain Chain, dstChain
 }
 
 // makes sure that a queued packet that is timed out (relative height timeout) will not be relayed
-func (ibc IBCTestCase) RelayPacketTestNoTimeout(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error {
+func (ibc IBCTestCase) RelayPacketTestNoTimeout(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error {
 	ctx, home, pool, network, cleanup, err := SetupTestRun(testName)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+
+	srcChain, dstChain, err := cf.Pair(testName)
+	if err != nil {
+		return fmt.Errorf("failed to get chain pair: %w", err)
+	}
 
 	var srcInitialBalance, dstInitialBalance int64
 	var txHash string
@@ -257,12 +267,17 @@ func (ibc IBCTestCase) RelayPacketTestNoTimeout(testName string, srcChain Chain,
 }
 
 // makes sure that a queued packet that is timed out (relative height timeout) will not be relayed
-func (ibc IBCTestCase) RelayPacketTestHeightTimeout(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error {
+func (ibc IBCTestCase) RelayPacketTestHeightTimeout(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error {
 	ctx, home, pool, network, cleanup, err := SetupTestRun(testName)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+
+	srcChain, dstChain, err := cf.Pair(testName)
+	if err != nil {
+		return fmt.Errorf("failed to get chain pair: %w", err)
+	}
 
 	var srcInitialBalance, dstInitialBalance int64
 	var txHash string
@@ -347,12 +362,17 @@ func (ibc IBCTestCase) RelayPacketTestHeightTimeout(testName string, srcChain Ch
 }
 
 // makes sure that a queued packet that is timed out (nanoseconds timeout) will not be relayed
-func (ibc IBCTestCase) RelayPacketTestTimestampTimeout(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error {
+func (ibc IBCTestCase) RelayPacketTestTimestampTimeout(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error {
 	ctx, home, pool, network, cleanup, err := SetupTestRun(testName)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
+
+	srcChain, dstChain, err := cf.Pair(testName)
+	if err != nil {
+		return fmt.Errorf("failed to get chain pair: %w", err)
+	}
 
 	var srcInitialBalance, dstInitialBalance int64
 	var txHash string

--- a/ibc/test_setup.go
+++ b/ibc/test_setup.go
@@ -34,12 +34,12 @@ const (
 	testPathName       = "test-path"
 )
 
-// all methods on this struct have the same signature and are method names that will be called by the CLI
-// func (ibc IBCTestCase) TestCaseName(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error
+// all methods on this struct have the same signature and are method names that will be called by the CLI:
+//     func (ibc IBCTestCase) TestCaseName(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error
 type IBCTestCase struct{}
 
 // uses reflection to get test case
-func GetTestCase(testCase string) (func(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error, error) {
+func GetTestCase(testCase string) (func(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error, error) {
 	v := reflect.ValueOf(IBCTestCase{})
 	m := v.MethodByName(testCase)
 
@@ -47,8 +47,8 @@ func GetTestCase(testCase string) (func(testName string, srcChain Chain, dstChai
 		return nil, fmt.Errorf("invalid test case: %s", testCase)
 	}
 
-	testCaseFunc := func(testName string, srcChain Chain, dstChain Chain, relayerImplementation RelayerImplementation) error {
-		args := []reflect.Value{reflect.ValueOf(testName), reflect.ValueOf(srcChain), reflect.ValueOf(dstChain), reflect.ValueOf(relayerImplementation)}
+	testCaseFunc := func(testName string, cf ChainFactory, relayerImplementation RelayerImplementation) error {
+		args := []reflect.Value{reflect.ValueOf(testName), reflect.ValueOf(cf), reflect.ValueOf(relayerImplementation)}
 		result := m.Call(args)
 		if len(result) != 1 || !result[0].CanInterface() {
 			return errors.New("error reflecting error return var")

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -9,47 +9,40 @@ import (
 
 // These tests are run by CI
 
-func getTestChains(t *testing.T) (ibc.Chain, ibc.Chain) {
-	numValidatorsPerChain := 4
-	numFullNodesPerChain := 1
-
-	srcChain, err := ibc.GetChain(t.Name(), "gaia", "v6.0.4", "cosmoshub-1004", numValidatorsPerChain, numFullNodesPerChain)
-	require.NoError(t, err)
-	dstChain, err := ibc.GetChain(t.Name(), "osmosis", "v7.0.4", "osmosis-1001", numValidatorsPerChain, numFullNodesPerChain)
-	require.NoError(t, err)
-
-	return srcChain, dstChain
+func getTestChainFactory(t *testing.T) ibc.ChainFactory {
+	return ibc.NewBuiltinChainFactory(
+		[]ibc.BuiltinChainFactoryEntry{
+			{Name: "gaia", Version: "v6.0.4", ChainID: "cosmoshub-1004", NumValidators: 4, NumFullNodes: 1},
+			{Name: "osmosis", Version: "v7.0.4", ChainID: "osmosis-1001", NumValidators: 4, NumFullNodes: 1},
+		},
+	)
 }
 
 // queued packet with default timeout should be relayed
 func TestRelayPacket(t *testing.T) {
-	srcChain, dstChain := getTestChains(t)
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTest(t.Name(), srcChain, dstChain, relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTest(t.Name(), getTestChainFactory(t), relayerImplementation))
 }
 
 // queued packet with no timeout should be relayed
 func TestNoTimeout(t *testing.T) {
-	srcChain, dstChain := getTestChains(t)
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestNoTimeout(t.Name(), srcChain, dstChain, relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestNoTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
 }
 
 // queued packet with relative height timeout that expires should not be relayed
 func TestHeightTimeout(t *testing.T) {
-	srcChain, dstChain := getTestChains(t)
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestHeightTimeout(t.Name(), srcChain, dstChain, relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestHeightTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
 }
 
 // queued packet with relative timestamp timeout (ns) that expires should not be relayed
 func TestTimestampTimeout(t *testing.T) {
 	t.Skip() // TODO turn this back on once fixed in cosmos relayer
-	srcChain, dstChain := getTestChains(t)
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestTimestampTimeout(t.Name(), srcChain, dstChain, relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestTimestampTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
 }

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -9,7 +9,7 @@ import (
 
 // These tests are run by CI
 
-func getTestChainFactory(t *testing.T) ibc.ChainFactory {
+func getTestChainFactory() ibc.ChainFactory {
 	return ibc.NewBuiltinChainFactory(
 		[]ibc.BuiltinChainFactoryEntry{
 			{Name: "gaia", Version: "v6.0.4", ChainID: "cosmoshub-1004", NumValidators: 4, NumFullNodes: 1},
@@ -22,21 +22,21 @@ func getTestChainFactory(t *testing.T) ibc.ChainFactory {
 func TestRelayPacket(t *testing.T) {
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTest(t.Name(), getTestChainFactory(t), relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTest(t.Name(), getTestChainFactory(), relayerImplementation))
 }
 
 // queued packet with no timeout should be relayed
 func TestNoTimeout(t *testing.T) {
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestNoTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestNoTimeout(t.Name(), getTestChainFactory(), relayerImplementation))
 }
 
 // queued packet with relative height timeout that expires should not be relayed
 func TestHeightTimeout(t *testing.T) {
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestHeightTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestHeightTimeout(t.Name(), getTestChainFactory(), relayerImplementation))
 }
 
 // queued packet with relative timestamp timeout (ns) that expires should not be relayed
@@ -44,5 +44,5 @@ func TestTimestampTimeout(t *testing.T) {
 	t.Skip() // TODO turn this back on once fixed in cosmos relayer
 	relayerImplementation := ibc.CosmosRly
 
-	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestTimestampTimeout(t.Name(), getTestChainFactory(t), relayerImplementation))
+	require.NoError(t, ibc.IBCTestCase{}.RelayPacketTestTimestampTimeout(t.Name(), getTestChainFactory(), relayerImplementation))
 }


### PR DESCRIPTION
And provide two implementations to cover the test and custom commands.

Most importantly, this will allow future tests to choose to start more
than two chains, to eventually cover a single relayer process handling
more than one path.