### PR TITLE
DRAFT: Add cmd/ibctest to provide a test binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Don't commit the ibctest.test file,
+# regardless of where it was built.
+ibctest.test

--- a/cmd/ibctest/README.md
+++ b/cmd/ibctest/README.md
@@ -1,0 +1,11 @@
+# ibctest
+
+This directory contains a test that can be parameterized at runtime,
+allowing a user to pick and choose what combinations of relayers and chains to test.
+
+You can run the tests during development with `go test`,
+but for general distribution, you would generate the executable with `go test -c`.
+
+The test binary supports a `-matrix` flag.
+See `example_matrix.json` for an example of what this can look like.
+You may need to reference the `testMatrix` type in `ibc_test.go`.

--- a/cmd/ibctest/example_matrix.json
+++ b/cmd/ibctest/example_matrix.json
@@ -1,0 +1,14 @@
+{
+  "Relayers": ["rly"],
+
+  "ChainSets": [
+    [
+      {"Name": "gaia", "Version": "v6.0.4", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
+      {"Name": "osmosis", "Version": "v7.0.4", "ChainID": "osmosis-1001", "NumValidators": 2, "NumFullNodes": 1}
+    ],
+    [
+      {"Name": "gaia", "Version": "v6.0.4", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
+      {"Name": "juno", "Version": "v3.0.0", "ChainID": "juno-1003", "NumValidators": 2, "NumFullNodes": 1}
+    ]
+  ]
+}

--- a/cmd/ibctest/ibc_test.go
+++ b/cmd/ibctest/ibc_test.go
@@ -1,0 +1,168 @@
+// Command ibctest allows running the relayer tests with command-line configuration.
+package ibctest
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/strangelove-ventures/ibc-test-framework/ibc"
+	"github.com/strangelove-ventures/ibc-test-framework/relayertest"
+)
+
+// The value of the extra flags this test supports.
+var mainFlags struct {
+	MatrixFile string
+}
+
+// The value of the test matrix.
+var testMatrix struct {
+	Relayers []string
+
+	ChainSets [][]ibc.BuiltinChainFactoryEntry
+
+	// TODO: support a slice of ibc.CustomChainFactoryEntry too.
+}
+
+func TestMain(m *testing.M) {
+	addFlags()
+	flag.Parse()
+
+	if err := setUpTestMatrix(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build test matrix: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := validateTestMatrix(); err != nil {
+		fmt.Fprintf(os.Stderr, "Test matrix invalid: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+// setUpTestMatrix populates the testMatrix singleton with
+// the parsed contents of the file referenced by the matrix flag,
+// or with a small reasonable default of rly against one gaia-osmosis set.
+func setUpTestMatrix() error {
+	if mainFlags.MatrixFile == "" {
+		fmt.Fprintln(os.Stderr, "No matrix file provided, falling back to rly with gaia and osmosis")
+
+		testMatrix.Relayers = []string{"rly"}
+		testMatrix.ChainSets = [][]ibc.BuiltinChainFactoryEntry{
+			{
+				{Name: "gaia", Version: "v6.0.4", ChainID: "cosmoshub-1004", NumValidators: 2, NumFullNodes: 1},
+				{Name: "osmosis", Version: "v7.0.4", ChainID: "osmosis-1001", NumValidators: 2, NumFullNodes: 1},
+			},
+		}
+
+		return nil
+	}
+
+	// Otherwise parse the given file.
+	fmt.Fprintf(os.Stderr, "Loading matrix file from %s\n", mainFlags.MatrixFile)
+	j, err := os.ReadFile(mainFlags.MatrixFile)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(j, &testMatrix); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTestMatrix() error {
+	for _, r := range testMatrix.Relayers {
+		if _, err := getRelayerFactory(r); err != nil {
+			return err
+		}
+	}
+
+	for _, cs := range testMatrix.ChainSets {
+		if _, err := getChainFactory(cs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getRelayerFactory(name string) (ibc.RelayerFactory, error) {
+	switch name {
+	case "rly", "cosmos/relayer":
+		return ibc.NewBuiltinRelayerFactory(ibc.CosmosRly), nil
+	case "hermes":
+		return ibc.NewBuiltinRelayerFactory(ibc.Hermes), nil
+	default:
+		return nil, fmt.Errorf("unknown relayer type %q (valid types: rly, hermes)", name)
+	}
+}
+
+func getChainFactory(chainSet []ibc.BuiltinChainFactoryEntry) (ibc.ChainFactory, error) {
+	if len(chainSet) != 2 {
+		return nil, fmt.Errorf("chain sets must have length 2 (found a chain set of length %d)", len(chainSet))
+	}
+
+	return ibc.NewBuiltinChainFactory(chainSet), nil
+}
+
+// TestRelayer is the root test for the relayer.
+// It runs each subtest in parallel;
+// if this is too taxing on a system, the -test.parallel flag
+// can be used to reduce how many tests actively run at once.
+func TestRelayer(t *testing.T) {
+	t.Parallel()
+
+	// One layer of subtests for each relayer to be tested.
+	for _, r := range testMatrix.Relayers {
+		rf, err := getRelayerFactory(r)
+		if err != nil {
+			// This error should have been validated before running tests.
+			panic(err)
+		}
+
+		t.Run(r, func(t *testing.T) {
+			t.Parallel()
+
+			// And another layer of subtests for each chainset.
+			for _, cs := range testMatrix.ChainSets {
+				cf, err := getChainFactory(cs)
+				if err != nil {
+					panic(err)
+				}
+
+				chainNames := make([]string, len(cs))
+				for i, c := range cs {
+					// TODO: this shouldn't need to truncate bits of the name and version,
+					// but without this, the tests hang on a failed container running gentx, with this error:
+					//    panic: failed to execute message; message index: 0: invalid moniker length; got: 75, max: 70
+					// It would be better to figure out the correct gentx invocation
+					// rather than hiding details from the test name.
+					chainNames[i] = c.Name[:3] + "@" + c.Version[1:]
+				}
+				chainTestName := strings.Join(chainNames, "+")
+
+				t.Run(chainTestName, func(t *testing.T) {
+					t.Parallel()
+
+					// Finally, the relayertest suite.
+					relayertest.TestRelayer(t, cf, rf)
+				})
+			}
+		})
+	}
+}
+
+// addFlags configures additional flags beyond the default testing flags.
+// Although pflag would have been slightly more developer friendly,
+// I ran out of time to spend on getting pflag to cooperate with the
+// testing flags, so I fell back to plain Go standard library flags.
+// We can revisit if necessary.
+func addFlags() {
+	flag.StringVar(&mainFlags.MatrixFile, "matrix", "", "Path to matrix file defining what configurations to test")
+}

--- a/ibc/cosmos_relayer.go
+++ b/ibc/cosmos_relayer.go
@@ -211,7 +211,7 @@ func (relayer *CosmosRelayer) CreateNodeContainer(pathName string) error {
 			User:       getDockerUserString(),
 			Cmd:        cmd,
 			Entrypoint: []string{},
-			Hostname:   containerName,
+			Hostname:   condenseHostName(containerName),
 			Image:      fmt.Sprintf("%s:%s", containerImage, containerVersion),
 			Labels:     map[string]string{"ibc-test": relayer.testName},
 		},

--- a/ibc/test_node.go
+++ b/ibc/test_node.go
@@ -603,7 +603,7 @@ func (tn *ChainNode) CreateNodeContainer() error {
 		Config: &docker.Config{
 			User:         getDockerUserString(),
 			Cmd:          cmd,
-			Hostname:     tn.Name(),
+			Hostname:     condenseHostName(tn.Name()),
 			ExposedPorts: sentryPorts,
 			DNS:          []string{},
 			Image:        fmt.Sprintf("%s:%s", chainCfg.Repository, chainCfg.Version),

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -48,7 +48,13 @@ func TestRelayer(t *testing.T, cf ibc.ChainFactory, rf ibc.RelayerFactory) {
 }
 
 func sanitizeTestNameForContainer(testName string) string {
-	return strings.ReplaceAll(testName, "/", "_")
+	// Subtests have slashes.
+	testName = strings.ReplaceAll(testName, "/", "_")
+
+	// Constructed subtest names in ibctest may contain + or @.
+	testName = strings.ReplaceAll(testName, "+", "_")
+	testName = strings.ReplaceAll(testName, "@", "_")
+	return testName
 }
 
 // TestingT is a subset of *testing.T,


### PR DESCRIPTION
This builds on #25 to demonstrate how to provide a `go test`-built binary, as opposed to providing a standalone binary that kind of acts like `go test`.

I personally have a strong preference for this approach, as it would enable us to use the existing utilities around `go test` while still controlling runtime parameters of which relayer and which chains to run in test. For instance, when using the matrix configuration file, we can rely on the default `go test` parallelism to run as many tests as you have CPU cores; or if that proves too taxing on your system, you can provide the `-test.parallel` flag. 

This DRAFT change is being proposed as work on top of #25, but if we choose this route, a fair portion of the code added in #25 would be removed.

(original commit message follows:)

----
There would be a bit of remaining work to get this production-ready.

- Remove the existing cmd package?
- Port the remaining ibc.IBCTest tests to the relayertest package
- Add a Makefile to build the ibctest binary
- Fix the moniker-too-long error instead of working around it
- Support custom chain factories instead of just the builtins