### PR TITLE
Make more code aware of *testing.T

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -115,7 +115,7 @@ func (tn *ChainNode) CliContext() client.Context {
 
 // Name is the hostname of the test node container
 func (tn *ChainNode) Name() string {
-	return fmt.Sprintf("node-%d-%s-%s", tn.Index, tn.Chain.Config().ChainID, tn.testName)
+	return fmt.Sprintf("node-%d-%s-%s", tn.Index, tn.Chain.Config().ChainID, utils.SanitizeContainerName(tn.testName))
 }
 
 // Dir is the directory where the test node files are stored

--- a/ibctest/relayerfactory.go
+++ b/ibctest/relayerfactory.go
@@ -2,6 +2,7 @@ package ibctest
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/ory/dockertest"
 	"github.com/strangelove-ventures/ibc-test-framework/ibc"
@@ -12,7 +13,7 @@ import (
 type RelayerFactory interface {
 	// Build returns a Relayer associated with the given arguments.
 	Build(
-		testName string,
+		t *testing.T,
 		pool *dockertest.Pool,
 		networkID string,
 		home string,
@@ -37,7 +38,7 @@ func NewBuiltinRelayerFactory(impl ibc.RelayerImplementation) RelayerFactory {
 
 // Build returns a relayer chosen depending on f.impl.
 func (f builtinRelayerFactory) Build(
-	testName string,
+	t *testing.T,
 	pool *dockertest.Pool,
 	networkID string,
 	home string,
@@ -46,7 +47,7 @@ func (f builtinRelayerFactory) Build(
 	switch f.impl {
 	case ibc.CosmosRly:
 		return rly.NewCosmosRelayerFromChains(
-			testName,
+			t,
 			srcChain,
 			dstChain,
 			pool,

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -72,14 +73,14 @@ func ChainConfigToCosmosRelayerChainConfig(chainConfig ibc.ChainConfig, keyName,
 	}
 }
 
-func NewCosmosRelayerFromChains(testName string, src, dst ibc.Chain, pool *dockertest.Pool, networkID string, home string) *CosmosRelayer {
+func NewCosmosRelayerFromChains(t *testing.T, src, dst ibc.Chain, pool *dockertest.Pool, networkID string, home string) *CosmosRelayer {
 	relayer := &CosmosRelayer{
 		src:       src,
 		dst:       dst,
 		pool:      pool,
 		networkID: networkID,
 		home:      home,
-		testName:  testName,
+		testName:  t.Name(),
 	}
 	relayer.MkDir()
 
@@ -87,7 +88,7 @@ func NewCosmosRelayerFromChains(testName string, src, dst ibc.Chain, pool *docke
 }
 
 func (relayer *CosmosRelayer) Name() string {
-	return fmt.Sprintf("rly-%s", relayer.testName)
+	return fmt.Sprintf("rly-%s", utils.SanitizeContainerName(relayer.testName))
 }
 
 func (relayer *CosmosRelayer) LinkPath(ctx context.Context, pathName string) error {

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -29,7 +29,6 @@
 package relayertest
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -69,25 +68,11 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	})
 }
 
-var validContainerCharsRE = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
-
-// sanitizeTestNameForContainer returns testName with any
-// invalid characters replaced with underscores.
-// Subtests will include slashes, and there may be other
-// invalid characters too.
-func sanitizeTestNameForContainer(testName string) string {
-	// Subtests contain slashes and other characters that are invalid for container names.
-	return validContainerCharsRE.ReplaceAllLiteralString(testName, "_")
-}
-
 func TestRelayer_RelayPacket(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory) {
-	testName := sanitizeTestNameForContainer(t.Name())
-
-	ctx, home, pool, network, cleanup, err := ibctest.SetupTestRun(testName)
+	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
 	require.NoErrorf(t, err, "failed to set up test run")
-	defer cleanup()
 
-	srcChain, dstChain, err := cf.Pair(testName)
+	srcChain, dstChain, err := cf.Pair(t.Name())
 	require.NoError(t, err, "failed to get chain pair")
 
 	// startup both chains and relayer
@@ -95,9 +80,8 @@ func TestRelayer_RelayPacket(t *testing.T, cf ibctest.ChainFactory, rf ibctest.R
 	// funds relayer src and dst wallets on respective chain in genesis
 	// creates a user account on the src chain (separate fullnode)
 	// funds user account on src chain in genesis
-	_, channels, srcUser, dstUser, rlyCleanup, err := ibctest.StartChainsAndRelayerFromFactory(testName, ctx, pool, network, home, srcChain, dstChain, rf, nil)
+	_, channels, srcUser, dstUser, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, pool, network, home, srcChain, dstChain, rf, nil)
 	require.NoError(t, err, "failed to StartChainsAndRelayerFromFactory")
-	defer rlyCleanup()
 
 	// will test a user sending an ibc transfer from the src chain to the dst chain
 	// denom will be src chain native denom
@@ -212,13 +196,10 @@ func TestRelayer_RelayPacket(t *testing.T, cf ibctest.ChainFactory, rf ibctest.R
 
 // Ensure that a queued packet that is timed out (relative height timeout) will not be relayed.
 func TestRelayer_RelayPacketNoTimeout(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory) {
-	testName := sanitizeTestNameForContainer(t.Name())
-
-	ctx, home, pool, network, cleanup, err := ibctest.SetupTestRun(testName)
+	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
 	require.NoErrorf(t, err, "failed to set up test run")
-	defer cleanup()
 
-	srcChain, dstChain, err := cf.Pair(testName)
+	srcChain, dstChain, err := cf.Pair(t.Name())
 	require.NoError(t, err, "failed to get chain pair")
 
 	var srcInitialBalance, dstInitialBalance int64
@@ -257,9 +238,8 @@ func TestRelayer_RelayPacketNoTimeout(t *testing.T, cf ibctest.ChainFactory, rf 
 	}
 
 	// Startup both chains and relayer
-	_, _, user, _, rlyCleanup, err := ibctest.StartChainsAndRelayerFromFactory(testName, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
+	_, _, user, _, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
 	require.NoError(t, err, "failed to StartChainsAndRelayerFromFactory")
-	defer rlyCleanup()
 
 	// wait for both chains to produce 10 blocks
 	require.NoError(t, ibctest.WaitForBlocks(srcChain, dstChain, 10), "failed to wait for blocks")
@@ -285,13 +265,10 @@ func TestRelayer_RelayPacketNoTimeout(t *testing.T, cf ibctest.ChainFactory, rf 
 
 // Ensure that a queued packet that is timed out (relative height timeout) will not be relayed.
 func TestRelayer_RelayPacketHeightTimeout(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory) {
-	testName := sanitizeTestNameForContainer(t.Name())
-
-	ctx, home, pool, network, cleanup, err := ibctest.SetupTestRun(testName)
+	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
 	require.NoErrorf(t, err, "failed to set up test run")
-	defer cleanup()
 
-	srcChain, dstChain, err := cf.Pair(testName)
+	srcChain, dstChain, err := cf.Pair(t.Name())
 	require.NoError(t, err, "failed to get chain pair")
 
 	var srcInitialBalance, dstInitialBalance int64
@@ -335,9 +312,8 @@ func TestRelayer_RelayPacketHeightTimeout(t *testing.T, cf ibctest.ChainFactory,
 	}
 
 	// Startup both chains and relayer
-	_, _, user, _, rlyCleanup, err := ibctest.StartChainsAndRelayerFromFactory(testName, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
+	_, _, user, _, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
 	require.NoError(t, err, "failed to StartChainsAndRelayerFromFactory")
-	defer rlyCleanup()
 
 	// wait for both chains to produce 10 blocks
 	require.NoError(t, ibctest.WaitForBlocks(srcChain, dstChain, 10), "failed to wait for blocks")
@@ -361,13 +337,10 @@ func TestRelayer_RelayPacketHeightTimeout(t *testing.T, cf ibctest.ChainFactory,
 }
 
 func TestRelayer_RelayPacketTimestampTimeout(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactory) {
-	testName := sanitizeTestNameForContainer(t.Name())
-
-	ctx, home, pool, network, cleanup, err := ibctest.SetupTestRun(testName)
+	ctx, home, pool, network, err := ibctest.SetupTestRun(t)
 	require.NoErrorf(t, err, "failed to set up test run")
-	defer cleanup()
 
-	srcChain, dstChain, err := cf.Pair(testName)
+	srcChain, dstChain, err := cf.Pair(t.Name())
 	require.NoError(t, err, "failed to get chain pair")
 
 	var srcInitialBalance, dstInitialBalance int64
@@ -413,9 +386,8 @@ func TestRelayer_RelayPacketTimestampTimeout(t *testing.T, cf ibctest.ChainFacto
 	}
 
 	// Startup both chains and relayer
-	_, _, user, _, rlyCleanup, err := ibctest.StartChainsAndRelayerFromFactory(testName, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
+	_, _, user, _, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStart)
 	require.NoError(t, err, "failed to StartChainsAndRelayerFromFactory")
-	defer rlyCleanup()
 
 	// wait for both chains to produce 10 blocks
 	require.NoError(t, ibctest.WaitForBlocks(srcChain, dstChain, 10), "failed to wait for blocks")

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -77,4 +78,14 @@ func CondenseHostName(name string) string {
 	// but that causes resolution problems for other hosts.
 	// Instead, use _._ which will be okay if there is a . on either end.
 	return name[:30] + "_._" + name[len(name)-30:]
+}
+
+var validContainerCharsRE = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+
+// SanitizeContainerName returns name with any
+// invalid characters replaced with underscores.
+// Subtests will include slashes, and there may be other
+// invalid characters too.
+func SanitizeContainerName(name string) string {
+	return validContainerCharsRE.ReplaceAllLiteralString(name, "_")
 }


### PR DESCRIPTION
In places where we were passing (*testing.T).Name(), prefer to pass the
plain *testing.T value. This makes the interfaces more amenable to
external definitions that are also used specifically in Go tests.

This allows use of t.Cleanup rather than returning callbacks that need
to be deferred.

When we need to sanitize test names for containers, do it later in the
call chains.