### PR TITLE
Support non-docker relayers

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -116,6 +116,18 @@ func (c *CosmosChain) GetGRPCAddress() string {
 	return fmt.Sprintf("%s:9090", c.getRelayerNode().Name())
 }
 
+// GetHostRPCAddress returns the address of the RPC server accessible by the host.
+// This will not return a valid address until the chain has been started.
+func (c *CosmosChain) GetHostRPCAddress() string {
+	return "http://" + utils.GetHostPort(c.getRelayerNode().Container, rpcPort)
+}
+
+// GetHostGRPCAddress returns the address of the gRPC server accessible by the host.
+// This will not return a valid address until the chain has been started.
+func (c *CosmosChain) GetHostGRPCAddress() string {
+	return utils.GetHostPort(c.getRelayerNode().Container, grpcPort)
+}
+
 // Implements Chain interface
 func (c *CosmosChain) CreateKey(ctx context.Context, keyName string) error {
 	return c.getRelayerNode().CreateKey(ctx, keyName)

--- a/ibc/Chain.go
+++ b/ibc/Chain.go
@@ -29,6 +29,14 @@ type Chain interface {
 	// retrieves grpc address that can be reached by other containers in the docker network
 	GetGRPCAddress() string
 
+	// GetHostRPCAddress returns the rpc address that can be reached by processes on the host machine.
+	// Note that this will not return a valid value until after Start returns.
+	GetHostRPCAddress() string
+
+	// GetHostGRPCAddress returns the grpc address that can be reached by processes on the host machine.
+	// Note that this will not return a valid value until after Start returns.
+	GetHostGRPCAddress() string
+
 	// get current height
 	Height() (int64, error)
 


### PR DESCRIPTION
For non-docker relayers, we need to provide the host-bound rpc and gRPC
addresses. Those addresses cannot be determined until the chain
containers are up and running. The relayer does not have an existing API
to modify a chain's addresses, so delay relayer configuration until
after chains are running.

However, we need certain accounts set up to perform chain genesis, so
generate those keys out of band, provide the account details to genesis,
and then restore the keys into a new relayer setup.