### PR TITLE
refactor: Misc cleanup + unit test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+default: help
+
+.PHONY: help
+help: ## Print this help message
+	@echo "Available make commands:"; grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: ibctest
-ibctest:
+ibctest: ## Build ibctest binary into ./bin
 	go test -c -o ./bin/ibctest ./cmd/ibctest
+
+.PHONY: test
+test: ## Run unit tests
+	@go test -cover -short -race -timeout=60s $(shell go list ./... | grep -v /cmd/)

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/avast/retry-go/v4"
 	"hash/fnv"
 	"io"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/avast/retry-go/v4"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -61,7 +62,7 @@ type ContainerPort struct {
 
 type Hosts []ContainerPort
 
-var (
+const (
 	valKey      = "validator"
 	blockTime   = 2 // seconds
 	p2pPort     = "26656/tcp"
@@ -69,7 +70,9 @@ var (
 	grpcPort    = "9090/tcp"
 	apiPort     = "1317/tcp"
 	privValPort = "1234/tcp"
+)
 
+var (
 	sentryPorts = map[docker.Port]struct{}{
 		docker.Port(p2pPort):     {},
 		docker.Port(rpcPort):     {},

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -119,13 +119,13 @@ func (c *CosmosChain) GetGRPCAddress() string {
 // GetHostRPCAddress returns the address of the RPC server accessible by the host.
 // This will not return a valid address until the chain has been started.
 func (c *CosmosChain) GetHostRPCAddress() string {
-	return "http://" + utils.GetHostPort(c.getRelayerNode().Container, rpcPort)
+	return "http://" + dockerutil.GetHostPort(c.getRelayerNode().Container, rpcPort)
 }
 
 // GetHostGRPCAddress returns the address of the gRPC server accessible by the host.
 // This will not return a valid address until the chain has been started.
 func (c *CosmosChain) GetHostGRPCAddress() string {
-	return utils.GetHostPort(c.getRelayerNode().Container, grpcPort)
+	return dockerutil.GetHostPort(c.getRelayerNode().Container, grpcPort)
 }
 
 // Implements Chain interface

--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	authTx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/strangelove-ventures/ibc-test-framework/dockerutil"
 	"github.com/strangelove-ventures/ibc-test-framework/ibc"
-	"github.com/strangelove-ventures/ibc-test-framework/utils"
 
 	"github.com/ory/dockertest"
 	"github.com/ory/dockertest/docker"
@@ -190,7 +190,7 @@ func (c *CosmosChain) Height() (int64, error) {
 // Implements Chain interface
 func (c *CosmosChain) GetBalance(ctx context.Context, address string, denom string) (int64, error) {
 	params := &bankTypes.QueryBalanceRequest{Address: address, Denom: denom}
-	grpcAddress := utils.GetHostPort(c.getRelayerNode().Container, grpcPort)
+	grpcAddress := dockerutil.GetHostPort(c.getRelayerNode().Container, grpcPort)
 	conn, err := grpc.Dial(grpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return 0, err

--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/strangelove-ventures/ibc-test-framework/ibc"
 	"github.com/strangelove-ventures/ibc-test-framework/ibctest"
@@ -28,6 +30,7 @@ var testMatrix struct {
 }
 
 func TestMain(m *testing.M) {
+	rand.Seed(time.Now().UnixNano())
 	addFlags()
 	flag.Parse()
 

--- a/dockerutil/docker.go
+++ b/dockerutil/docker.go
@@ -1,4 +1,4 @@
-package utils
+package dockerutil
 
 import (
 	"crypto/rand"
@@ -64,7 +64,7 @@ func GetDockerUserString() string {
 	return usr
 }
 
-// condenseHostName truncates the middle of the given name
+// CondenseHostName truncates the middle of the given name
 // if it is 64 characters or longer.
 //
 // Without this helper, you may see an error like:

--- a/dockerutil/errors.go
+++ b/dockerutil/errors.go
@@ -2,7 +2,7 @@ package dockerutil
 
 import "fmt"
 
-func HandleNodeJobError(exitCode int, stdout, stderr string, err error) error {
+func HandleNodeJobError(exitCode int, _, _ string, err error) error {
 	if err != nil {
 		return err
 	}

--- a/dockerutil/errors.go
+++ b/dockerutil/errors.go
@@ -1,0 +1,13 @@
+package dockerutil
+
+import "fmt"
+
+func HandleNodeJobError(exitCode int, stdout, stderr string, err error) error {
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("container returned non-zero error code: %d\n", exitCode)
+	}
+	return nil
+}

--- a/dockerutil/errors_test.go
+++ b/dockerutil/errors_test.go
@@ -1,0 +1,7 @@
+package dockerutil
+
+import "testing"
+
+func TestHandleNodeJobError(t *testing.T) {
+
+}

--- a/dockerutil/errors_test.go
+++ b/dockerutil/errors_test.go
@@ -1,7 +1,18 @@
 package dockerutil
 
-import "testing"
+import (
+	"errors"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
 
 func TestHandleNodeJobError(t *testing.T) {
+	err := HandleNodeJobError(0, "", "", nil)
+	require.NoError(t, err)
 
+	err = HandleNodeJobError(1, "", "", nil)
+	require.Error(t, err)
+
+	err = HandleNodeJobError(0, "", "", errors.New("oops"))
+	require.Error(t, err)
 }

--- a/dockerutil/strings.go
+++ b/dockerutil/strings.go
@@ -2,12 +2,13 @@ package dockerutil
 
 import (
 	"fmt"
-	"github.com/ory/dockertest/docker"
 	"math/rand"
 	"net"
 	"os"
 	"regexp"
 	"runtime"
+
+	"github.com/ory/dockertest/docker"
 )
 
 // GetHostPort returns a resource's published port with an address.
@@ -42,8 +43,7 @@ func RandLowerCaseLetterString(length int) string {
 func GetDockerUserString() string {
 	uid := os.Getuid()
 	var usr string
-	userOS := runtime.GOOS
-	if userOS == "darwin" {
+	if runtime.GOOS == "darwin" {
 		usr = ""
 	} else {
 		usr = fmt.Sprintf("%d:%d", uid, uid)

--- a/dockerutil/strings.go
+++ b/dockerutil/strings.go
@@ -29,11 +29,11 @@ func GetHostPort(cont *docker.Container, portID string) string {
 	return net.JoinHostPort(ip, m[0].HostPort)
 }
 
-var chars = []rune("abcdefghijklmnopqrstuvwxyz")
+var chars = []byte("abcdefghijklmnopqrstuvwxyz")
 
 // RandLowerCaseLetterString returns a lowercase letter string of given length
 func RandLowerCaseLetterString(length int) string {
-	b := make([]rune, length)
+	b := make([]byte, length)
 	for i := range b {
 		b[i] = chars[rand.Intn(length)]
 	}

--- a/dockerutil/strings.go
+++ b/dockerutil/strings.go
@@ -1,16 +1,13 @@
 package dockerutil
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math/big"
+	"github.com/ory/dockertest/docker"
+	"math/rand"
 	"net"
 	"os"
 	"regexp"
 	"runtime"
-	"strings"
-
-	"github.com/ory/dockertest/docker"
 )
 
 // GetHostPort returns a resource's published port with an address.
@@ -31,25 +28,15 @@ func GetHostPort(cont *docker.Container, portID string) string {
 	return net.JoinHostPort(ip, m[0].HostPort)
 }
 
+var chars = []rune("abcdefghijklmnopqrstuvwxyz")
+
 // RandLowerCaseLetterString returns a lowercase letter string of given length
 func RandLowerCaseLetterString(length int) string {
-	chars := []rune("abcdefghijklmnopqrstuvwxyz")
-	var b strings.Builder
-	for i := 0; i < length; i++ {
-		i, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
-		b.WriteRune(chars[i.Int64()])
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = chars[rand.Intn(length)]
 	}
-	return b.String()
-}
-
-func HandleNodeJobError(exitCode int, stdout, stderr string, err error) error {
-	if err != nil {
-		return err
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("container returned non-zero error code: %d\n", exitCode)
-	}
-	return nil
+	return string(b)
 }
 
 func GetDockerUserString() string {

--- a/dockerutil/strings_test.go
+++ b/dockerutil/strings_test.go
@@ -1,0 +1,74 @@
+package dockerutil
+
+import (
+	"github.com/ory/dockertest/docker"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+)
+
+func TestGetHostPort(t *testing.T) {
+	for _, tt := range []struct {
+		Container *docker.Container
+		PortID    string
+		Want      string
+	}{
+		{&docker.Container{
+			NetworkSettings: &docker.NetworkSettings{
+				Ports: map[docker.Port][]docker.PortBinding{"test": {
+					{HostIP: "1.2.3.4", HostPort: "8080"}, {HostIP: "0.0.0.0", HostPort: "9999"}},
+				},
+			},
+		}, "test", "1.2.3.4:8080"},
+
+		{&docker.Container{
+			NetworkSettings: &docker.NetworkSettings{
+				Ports: map[docker.Port][]docker.PortBinding{"test": {
+					{HostIP: "0.0.0.0", HostPort: "3000"}},
+				},
+			},
+		}, "test", "localhost:3000"},
+
+		{nil, "", ""},
+		{&docker.Container{}, "", ""},
+		{&docker.Container{NetworkSettings: &docker.NetworkSettings{}}, "does-not-matter", ""},
+	} {
+		require.Equal(t, tt.Want, GetHostPort(tt.Container, tt.PortID), tt)
+	}
+}
+
+func TestRandLowerCaseLetterString(t *testing.T) {
+	require.Empty(t, RandLowerCaseLetterString(0))
+
+	rand.Seed(1)
+
+	const want = `fdllbgbieach`
+	require.Equal(t, want, RandLowerCaseLetterString(12))
+}
+
+func TestCondenseHostName(t *testing.T) {
+	for _, tt := range []struct {
+		HostName, Want string
+	}{
+		{"", ""},
+		{"test", "test"},
+		{"some-really-very-incredibly-long-hostname-that-is-greater-than-64-characters", "some-really-very-incredibly-lo_._-is-greater-than-64-characters"},
+	} {
+		require.Equal(t, tt.Want, CondenseHostName(tt.HostName), tt)
+	}
+}
+
+func TestSanitizeContainerName(t *testing.T) {
+	for _, tt := range []struct {
+		Name, Want string
+	}{
+		{"hello-there", "hello-there"},
+		{"hello@there", "hello_there"},
+		{"hello@/there", "hello__there"},
+		// edge cases
+		{"?", "_"},
+		{"", ""},
+	} {
+		require.Equal(t, tt.Want, SanitizeContainerName(tt.Name), tt)
+	}
+}

--- a/ibctest/test_setup.go
+++ b/ibctest/test_setup.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/ory/dockertest"
 	"github.com/ory/dockertest/docker"
+	"github.com/strangelove-ventures/ibc-test-framework/dockerutil"
 	"github.com/strangelove-ventures/ibc-test-framework/ibc"
-	"github.com/strangelove-ventures/ibc-test-framework/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -66,7 +66,7 @@ func SetupTestRun(t *testing.T) (context.Context, string, *dockertest.Pool, stri
 
 	home := t.TempDir()
 
-	networkName := fmt.Sprintf("ibc-test-framework-%s", utils.RandLowerCaseLetterString(8))
+	networkName := fmt.Sprintf("ibc-test-framework-%s", dockerutil.RandLowerCaseLetterString(8))
 	network, err := CreateTestNetwork(pool, networkName, t.Name())
 	if err != nil {
 		return ctx, "", nil, "", err

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -20,5 +20,8 @@ func getTestChainFactory() ibctest.ChainFactory {
 }
 
 func TestRelayer(t *testing.T) {
+	if testing.Short() {
+		return
+	}
 	relayertest.TestRelayer(t, getTestChainFactory(), ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly))
 }

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -21,7 +21,7 @@ func getTestChainFactory() ibctest.ChainFactory {
 
 func TestRelayer(t *testing.T) {
 	if testing.Short() {
-		return
+		t.Skip()
 	}
 	relayertest.TestRelayer(t, getTestChainFactory(), ibctest.NewBuiltinRelayerFactory(ibc.CosmosRly))
 }


### PR DESCRIPTION
# Description, Motivation, and Context

* Rename `utils` -> `dockerutil` to clarify the intention of that package. Seems like a safe name given every function in there is to help with docker related things. https://dave.cheney.net/2019/01/08/avoid-package-names-like-base-util-or-common
* Add unit test coverage for above package
* Update Makefile for unit tests

## Known Limitations, Trade-offs, Tech Debt
- NA