### PR TITLE
Add ibc-test-maintainers team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @strangelove-ventures/ibc-test-maintainers


### PR DESCRIPTION
With the team settings, GitHub should now automatically pick a member of
the team to review changes to this repository.