### PR TITLE
Omit src and dst chains from RelayerFactory.Build

### DIFF
--- a/ibctest/relayerfactory.go
+++ b/ibctest/relayerfactory.go
@@ -17,7 +17,6 @@ type RelayerFactory interface {
 		pool *dockertest.Pool,
 		networkID string,
 		home string,
-		srcChain, dstChain ibc.Chain,
 	) ibc.Relayer
 
 	// UseDockerNetwork reports whether the relayer is run in the same docker network as the other chains.
@@ -42,14 +41,11 @@ func (f builtinRelayerFactory) Build(
 	pool *dockertest.Pool,
 	networkID string,
 	home string,
-	srcChain, dstChain ibc.Chain,
 ) ibc.Relayer {
 	switch f.impl {
 	case ibc.CosmosRly:
 		return rly.NewCosmosRelayerFromChains(
 			t,
-			srcChain,
-			dstChain,
 			pool,
 			networkID,
 			home,

--- a/ibctest/test_setup.go
+++ b/ibctest/test_setup.go
@@ -119,7 +119,7 @@ func StartChainsAndRelayerFromFactory(
 	f RelayerFactory,
 	preRelayerStart func([]ibc.ChannelOutput, User, User) error,
 ) (ibc.Relayer, []ibc.ChannelOutput, *User, *User, error) {
-	relayerImpl := f.Build(t, pool, networkID, home, srcChain, dstChain)
+	relayerImpl := f.Build(t, pool, networkID, home)
 
 	errResponse := func(err error) (ibc.Relayer, []ibc.ChannelOutput, *User, *User, error) {
 		return nil, []ibc.ChannelOutput{}, nil, nil, err

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -19,8 +19,6 @@ import (
 )
 
 type CosmosRelayer struct {
-	src       ibc.Chain
-	dst       ibc.Chain
 	pool      *dockertest.Pool
 	container *docker.Container
 	networkID string
@@ -73,10 +71,8 @@ func ChainConfigToCosmosRelayerChainConfig(chainConfig ibc.ChainConfig, keyName,
 	}
 }
 
-func NewCosmosRelayerFromChains(t *testing.T, src, dst ibc.Chain, pool *dockertest.Pool, networkID string, home string) *CosmosRelayer {
+func NewCosmosRelayerFromChains(t *testing.T, pool *dockertest.Pool, networkID string, home string) *CosmosRelayer {
 	relayer := &CosmosRelayer{
-		src:       src,
-		dst:       dst,
 		pool:      pool,
 		networkID: networkID,
 		home:      home,


### PR DESCRIPTION
First, these are not used by any existing RelayerFactory implementation.
Second, coupling relayer instances to a pair of chains will
overcomplicate upcoming many-chain relayer tests.