### PR TITLE
Fix indexing into alphabet for random characters

### DIFF
--- a/dockerutil/strings.go
+++ b/dockerutil/strings.go
@@ -35,7 +35,7 @@ var chars = []byte("abcdefghijklmnopqrstuvwxyz")
 func RandLowerCaseLetterString(length int) string {
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = chars[rand.Intn(length)]
+		b[i] = chars[rand.Intn(len(chars))]
 	}
 	return string(b)
 }

--- a/dockerutil/strings_test.go
+++ b/dockerutil/strings_test.go
@@ -1,10 +1,11 @@
 package dockerutil
 
 import (
-	"github.com/ory/dockertest/docker"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
+
+	"github.com/ory/dockertest/docker"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHostPort(t *testing.T) {
@@ -41,9 +42,10 @@ func TestRandLowerCaseLetterString(t *testing.T) {
 	require.Empty(t, RandLowerCaseLetterString(0))
 
 	rand.Seed(1)
+	require.Equal(t, "xvlbzgbaicmr", RandLowerCaseLetterString(12))
 
-	const want = `fdllbgbieach`
-	require.Equal(t, want, RandLowerCaseLetterString(12))
+	rand.Seed(1)
+	require.Equal(t, "xvlbzgbaicmrajwwhthctcuaxhxkqf", RandLowerCaseLetterString(30))
 }
 
 func TestCondenseHostName(t *testing.T) {


### PR DESCRIPTION
I kept seeing test with suffixes only composed of characters a, b, and
c. This was because it was only using the requested length for indexing
into the alphabet, and those tests were requesting a random string of
length 3.