### PR TITLE
Better docker cleanup

### DIFF
--- a/chain/cosmos/cosmos_chain.go
+++ b/chain/cosmos/cosmos_chain.go
@@ -108,12 +108,12 @@ func (c *CosmosChain) getRelayerNode() *ChainNode {
 
 // Implements Chain interface
 func (c *CosmosChain) GetRPCAddress() string {
-	return fmt.Sprintf("http://%s:26657", c.getRelayerNode().Name())
+	return fmt.Sprintf("http://%s:26657", dockerutil.CondenseHostName(c.getRelayerNode().Name()))
 }
 
 // Implements Chain interface
 func (c *CosmosChain) GetGRPCAddress() string {
-	return fmt.Sprintf("%s:9090", c.getRelayerNode().Name())
+	return fmt.Sprintf("%s:9090", dockerutil.CondenseHostName(c.getRelayerNode().Name()))
 }
 
 // GetHostRPCAddress returns the address of the RPC server accessible by the host.

--- a/cmd/ibctest/example_matrix.json
+++ b/cmd/ibctest/example_matrix.json
@@ -3,12 +3,12 @@
 
   "ChainSets": [
     [
-      {"Name": "gaia", "Version": "v6.0.4", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
-      {"Name": "osmosis", "Version": "v7.0.4", "ChainID": "osmosis-1001", "NumValidators": 2, "NumFullNodes": 1}
+      {"Name": "gaia", "Version": "latest", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
+      {"Name": "osmosis", "Version": "latest", "ChainID": "osmosis-1001", "NumValidators": 2, "NumFullNodes": 1}
     ],
     [
-      {"Name": "gaia", "Version": "v6.0.4", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
-      {"Name": "juno", "Version": "v3.0.0", "ChainID": "juno-1003", "NumValidators": 2, "NumFullNodes": 1}
+      {"Name": "gaia", "Version": "latest", "ChainID": "cosmoshub-1004", "NumValidators": 2, "NumFullNodes": 1},
+      {"Name": "juno", "Version": "latest", "ChainID": "juno-1003", "NumValidators": 2, "NumFullNodes": 1}
     ]
   ]
 }

--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -57,8 +57,8 @@ func setUpTestMatrix() error {
 		testMatrix.Relayers = []string{"rly"}
 		testMatrix.ChainSets = [][]ibctest.BuiltinChainFactoryEntry{
 			{
-				{Name: "gaia", Version: "v6.0.4", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
-				{Name: "osmosis", Version: "v7.0.4", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
+				{Name: "gaia", Version: "latest", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
+				{Name: "osmosis", Version: "latest", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
 			},
 		}
 

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -266,7 +266,7 @@ func (relayer *CosmosRelayer) NodeJob(ctx context.Context, cmd []string) (int, s
 			Image:      fmt.Sprintf("%s:%s", containerImage, containerVersion),
 			Cmd:        cmd,
 			Entrypoint: []string{},
-			Labels:     map[string]string{"ibc-test": container},
+			Labels:     map[string]string{"ibc-test": relayer.testName},
 		},
 		NetworkingConfig: &docker.NetworkingConfig{
 			EndpointsConfig: map[string]*docker.EndpointConfig{

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -13,8 +13,8 @@ import (
 func getTestChainFactory() ibctest.ChainFactory {
 	return ibctest.NewBuiltinChainFactory(
 		[]ibctest.BuiltinChainFactoryEntry{
-			{Name: "gaia", Version: "latest", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
-			{Name: "osmosis", Version: "latest", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
+			{Name: "gaia", Version: "v7.0.1", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
+			{Name: "osmosis", Version: "v7.2.0", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
 		},
 	)
 }

--- a/test/relayer_test.go
+++ b/test/relayer_test.go
@@ -13,8 +13,8 @@ import (
 func getTestChainFactory() ibctest.ChainFactory {
 	return ibctest.NewBuiltinChainFactory(
 		[]ibctest.BuiltinChainFactoryEntry{
-			{Name: "gaia", Version: "v6.0.4", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
-			{Name: "osmosis", Version: "v7.0.4", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
+			{Name: "gaia", Version: "latest", ChainID: "cosmoshub-1004", NumValidators: 1, NumFullNodes: 1},
+			{Name: "osmosis", Version: "latest", ChainID: "osmosis-1001", NumValidators: 1, NumFullNodes: 1},
 		},
 	)
 }


### PR DESCRIPTION
- Run cleanup before and after
- Fix missing cleanup for rly docker `NodeJob`s
- Use latest images for example matrix. Keep fixed versions for CI