### PR TITLE
script: Add docker helper commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,12 @@ ibctest: ## Build ibctest binary into ./bin
 .PHONY: test
 test: ## Run unit tests
 	@go test -cover -short -race -timeout=60s $(shell go list ./... | grep -v /cmd/)
+
+.PHONY: docker-reset
+docker-reset: ## Attempt to delete all running containers. Useful if ibctest does not exit cleanly.
+	docker stop $$(docker ps -q)
+	docker rm --force $$(docker ps -q)
+
+.PHONY: docker-mac-nuke
+docker-mac-nuke: ## macOS only. Try docker-reset first. Kills and restarts Docker Desktop.
+	killall -9 Docker && open /Applications/Docker.app

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ test: ## Run unit tests
 
 .PHONY: docker-reset
 docker-reset: ## Attempt to delete all running containers. Useful if ibctest does not exit cleanly.
-	docker stop $$(docker ps -q)
-	docker rm --force $$(docker ps -q)
+	@docker stop $(shell docker ps -q) &>/dev/null || true
+	@docker rm --force $(shell docker ps -q) &>/dev/null || true
 
 .PHONY: docker-mac-nuke
 docker-mac-nuke: ## macOS only. Try docker-reset first. Kills and restarts Docker Desktop.


### PR DESCRIPTION
Docker on Mac can be finicky.

These commands usually do the trick. 