### PR TITLE
feat: Assert presence of acknowledgments

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -101,7 +101,6 @@ func (tn *ChainNode) NewClient(addr string) error {
 
 	tn.Client = rpcClient
 	return nil
-
 }
 
 // CliContext creates a new Cosmos SDK client context
@@ -354,7 +353,6 @@ type IBCTransferTx struct {
 	TxHash string `json:"txhash"`
 }
 
-// CollectGentxs runs collect gentxs on the node's home folders
 func (tn *ChainNode) SendIBCTransfer(ctx context.Context, channelID string, keyName string, amount ibc.WalletAmount, timeout *ibc.IBCTimeout) (string, error) {
 	command := []string{tn.Chain.Config().Bin, "tx", "ibc-transfer", "transfer", "transfer", channelID,
 		amount.Address, fmt.Sprintf("%d%s", amount.Amount, amount.Denom),

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -393,3 +393,7 @@ func (c *PenumbraChain) start(testName string, ctx context.Context, genesis Penu
 	_, err = c.getRelayerNode().TendermintNode.WaitForBlocks(5)
 	return err
 }
+
+func (c *PenumbraChain) GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]ibc.PacketAcknowledgment, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/ibc/Chain.go
+++ b/ibc/Chain.go
@@ -76,4 +76,7 @@ type Chain interface {
 
 	// fetch transaction
 	GetTransaction(ctx context.Context, txHash string) (*types.TxResponse, error)
+
+	// GetPacketAcknowledgments fetches ibc packet acks
+	GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]PacketAcknowledgment, error)
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -64,3 +64,9 @@ const (
 	CosmosRly RelayerImplementation = iota
 	Hermes
 )
+
+type PacketAcknowledgment struct {
+	Data   []byte
+	Height uint64
+	Seq    uint64
+}

--- a/ibctest/log.go
+++ b/ibctest/log.go
@@ -10,12 +10,12 @@ import (
 func CreateLogFile(name string) (*os.File, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("UserHomeDir: %w", err)
+		return nil, fmt.Errorf("user home dir: %w", err)
 	}
 	fpath := filepath.Join(home, ".ibctest", "logs")
 	err = os.MkdirAll(fpath, 0755)
 	if err != nil {
-		return nil, fmt.Errorf("MkdirAll: %w", err)
+		return nil, fmt.Errorf("mkdirall: %w", err)
 	}
 	return os.Create(filepath.Join(fpath, name))
 }

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -145,14 +145,11 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 		eg        errgroup.Group
 		txHashSrc string
 		txHashDst string
-
-		srcChannelID = channels[0].ChannelID
-		dstChannelID = channels[0].Counterparty.ChannelID
 	)
 
 	eg.Go(func() error {
 		var err error
-		t.Logf("Sending ibc transfer from %s to %s on channel %s", srcChain.Config().ChainID, dstChain.Config().ChainID, srcChannelID)
+		srcChannelID := channels[0].ChannelID
 		txHashSrc, err = srcChain.SendIBCTransfer(ctx, srcChannelID, srcUser.KeyName, testCoinSrcToDst, timeout)
 		if err != nil {
 			return fmt.Errorf("failed to send ibc transfer from source: %w", err)
@@ -162,7 +159,7 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 
 	eg.Go(func() error {
 		var err error
-		t.Logf("Sending ibc transfer from %s to %s on channel %s", dstChain.Config().ChainID, srcChain.Config().ChainID, dstChannelID)
+		dstChannelID := channels[0].Counterparty.ChannelID
 		txHashDst, err = dstChain.SendIBCTransfer(ctx, dstChannelID, dstUser.KeyName, testCoinDstToSrc, timeout)
 		if err != nil {
 			return fmt.Errorf("failed to send ibc transfer from destination: %w", err)
@@ -273,7 +270,7 @@ func testPacketRelaySuccess(
 	dstChainCfg := dstChain.Config()
 
 	// [BEGIN] assert on source to destination transfer
-	t.Logf("Asserting %s (source) to %s (destination) transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
+	t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
 	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
 	srcInitialBalance := userFaucetFund
 	dstInitialBalance := int64(0)
@@ -305,7 +302,7 @@ func testPacketRelaySuccess(
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
-	t.Logf("Asserting %s (destination) to %s (source) transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
+	t.Logf("Asserting %s to %s transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
 	dstUser := testCase.Users[1]
 	dstDenom := dstChainCfg.Denom
 	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now


### PR DESCRIPTION
# Description, Motivation, and Context

A baby step toward channel packet acknowledgments. We only assert that acks exist. 

## Known Limitations, Trade-offs, Tech Debt
* I don't think we can assert a specific ack count given the parallel nature of the test suite. It could be racy.
* I explored replacing `WaitForBlocks` with `WaitForAcks` but got an order of operations error: `failed to start dest chain: rpc error: code = Unavailable desc = connection closed before server preface received` which leads me to think the node is not ready yet. Therefore, I punted on that refactor (for a future PR). The `cosmos chain` sometimes makes cli commands and sometimes makes rpc/grpc calls.