### PR TITLE
feat: Assert IBC packet acknowledgments

### DIFF
--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -101,7 +101,6 @@ func (tn *ChainNode) NewClient(addr string) error {
 
 	tn.Client = rpcClient
 	return nil
-
 }
 
 // CliContext creates a new Cosmos SDK client context
@@ -354,7 +353,6 @@ type IBCTransferTx struct {
 	TxHash string `json:"txhash"`
 }
 
-// CollectGentxs runs collect gentxs on the node's home folders
 func (tn *ChainNode) SendIBCTransfer(ctx context.Context, channelID string, keyName string, amount ibc.WalletAmount, timeout *ibc.IBCTimeout) (string, error) {
 	command := []string{tn.Chain.Config().Bin, "tx", "ibc-transfer", "transfer", "transfer", channelID,
 		amount.Address, fmt.Sprintf("%d%s", amount.Amount, amount.Denom),

--- a/chain/cosmos/chain_node.go
+++ b/chain/cosmos/chain_node.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/strangelove-ventures/ibc-test-framework/chain/tendermint"
 	"github.com/strangelove-ventures/ibc-test-framework/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -202,6 +203,8 @@ func (tn *ChainNode) SetValidatorConfigAndPeers(peers string) {
 
 // Wait until we have signed n blocks in a row
 func (tn *ChainNode) WaitForBlocks(blocks int64) (int64, error) {
+	ctx := context.Background()
+
 	stat, err := tn.Client.Status(context.Background())
 	if err != nil {
 		return -1, err
@@ -211,29 +214,56 @@ func (tn *ChainNode) WaitForBlocks(blocks int64) (int64, error) {
 	mostRecentBlock := startingBlock
 	tn.logger().
 		WithField("initialHeight", startingBlock).
-		Info("wait for blocks")
+		Debug("wait for blocks")
+
 	// timeout after ~1 minute plus block time
 	timeoutSeconds := blocks*int64(blockTime) + int64(60)
 	for i := int64(0); i < timeoutSeconds; i++ {
 		time.Sleep(1 * time.Second)
 
-		stat, err := tn.Client.Status(context.Background())
+		stat, err := tn.Client.Status(ctx)
 		if err != nil {
 			return mostRecentBlock, err
 		}
 
 		mostRecentBlock = stat.SyncInfo.LatestBlockHeight
 
+		tn.maybeLogBlock(mostRecentBlock)
+
 		deltaBlocks := mostRecentBlock - startingBlock
 
 		if deltaBlocks >= blocks {
 			tn.logger().
 				WithField("initialHeight", startingBlock).
-				Infof("Time (sec) waiting for %d blocks: %d", blocks, i+1)
+				Debugf("Time (sec) waiting for %d blocks: %d", blocks, i+1)
 			return mostRecentBlock, nil // done waiting for consecutive signed blocks
 		}
 	}
 	return mostRecentBlock, errors.New("timed out waiting for blocks")
+}
+
+func (tn *ChainNode) maybeLogBlock(height int64) {
+	if tn.logger().Level() != "debug" {
+		return
+	}
+	ctx := context.Background()
+	blockRes, err := tn.Client.Block(ctx, &height)
+	if err != nil {
+		tn.logger().Error(err)
+		return
+	}
+	txs := blockRes.Block.Txs
+	if len(txs) == 0 {
+		return
+	}
+	pp, err := tendermint.PrettyPrintTxs(ctx, txs, tn.Client.Tx)
+	if err != nil {
+		tn.logger().Error(err)
+		return
+	}
+	tn.logger().
+		WithField("block", height).
+		Debug(pp)
 }
 
 func (tn *ChainNode) Height() (int64, error) {
@@ -684,7 +714,6 @@ func (tn *ChainNode) StartContainer(ctx context.Context) error {
 	return retry.Do(func() error {
 		stat, err := tn.Client.Status(ctx)
 		if err != nil {
-			// tn.t.Log(err)
 			return err
 		}
 		// TODO: reenable this check, having trouble with it for some reason

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -393,3 +393,7 @@ func (c *PenumbraChain) start(testName string, ctx context.Context, genesis Penu
 	_, err = c.getRelayerNode().TendermintNode.WaitForBlocks(5)
 	return err
 }
+
+func (c *PenumbraChain) GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]ibc.PacketAcknowledgment, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -44,10 +44,10 @@ func NewPenumbraChainConfig() ibc.ChainConfig {
 		GasAdjustment:  1.3,
 		TrustingPeriod: "672h",
 		Images: []ibc.ChainDockerImage{
-			ibc.ChainDockerImage{
+			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/tendermint",
 			},
-			ibc.ChainDockerImage{
+			{
 				Repository: "ghcr.io/strangelove-ventures/heighliner/penumbra",
 			},
 		},

--- a/chain/penumbra/penumbra_chain.go
+++ b/chain/penumbra/penumbra_chain.go
@@ -394,6 +394,10 @@ func (c *PenumbraChain) start(testName string, ctx context.Context, genesis Penu
 	return err
 }
 
-func (c *PenumbraChain) GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]ibc.PacketAcknowledgment, error) {
-	return nil, errors.New("not yet implemented")
+func (c *PenumbraChain) GetPacketAcknowledgment(ctx context.Context, portID, channelID string, seq uint64) (ibc.PacketAcknowledgment, error) {
+	panic("not implemented")
+}
+
+func (c *PenumbraChain) GetPacketSequence(ctx context.Context, txHash string) (uint64, error) {
+	panic("not implemented")
 }

--- a/chain/tendermint/tendermint.go
+++ b/chain/tendermint/tendermint.go
@@ -6,9 +6,27 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
+
+// AttributeValue returns an event attribute value given the eventType and attribute key tuple.
+// In the event of duplicate types and keys, returns the first attribute value found.
+// If not found, ok is false.
+func AttributeValue(events []abcitypes.Event, eventType string, attrKey []byte) (found []byte, ok bool) {
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		for _, attr := range event.Attributes {
+			if bytes.Equal(attr.Key, attrKey) {
+				return attr.Value, true
+			}
+		}
+	}
+	return nil, false
+}
 
 // PrettyPrintTxs pretty prints tendermint transactions and events
 func PrettyPrintTxs(ctx context.Context, txs types.Txs, getTx func(ctx context.Context, hash []byte, prove bool) (*coretypes.ResultTx, error)) (string, error) {

--- a/chain/tendermint/tendermint.go
+++ b/chain/tendermint/tendermint.go
@@ -1,0 +1,41 @@
+package tendermint
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/davecgh/go-spew/spew"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+)
+
+// PrettyPrintBlock pretty prints tendermint block, all its transactions, and events
+func PrettyPrintBlock(ctx context.Context, client rpcclient.SignClient, height int64) (string, error) {
+	blockRes, err := client.Block(ctx, &height)
+	if err != nil {
+		return "", fmt.Errorf("tendermint rpc get block: %w", err)
+	}
+	buf := new(bytes.Buffer)
+	buf.WriteString("BLOCK " + strconv.FormatInt(height, 10) + "\n")
+
+	for i, tx := range blockRes.Block.Txs {
+		buf.WriteString(fmt.Sprintf("TX %d:\n", i))
+		buf.WriteString(tx.String() + "\n")
+
+		// Tx data may contain useful information such as protobuf message type but will be
+		// mixed in with non-human readable data.
+		buf.WriteString("DATA:\n")
+		buf.Write(tx)
+		buf.WriteString("\n")
+
+		resTx, err := client.Tx(ctx, tx.Hash(), false)
+		if err != nil {
+			return "", fmt.Errorf("tendermint rpc get tx: %w", err)
+		}
+		buf.WriteString("EVENTS:\n")
+		spew.Fdump(buf, resTx.TxResult.Events)
+	}
+
+	return buf.String(), nil
+}

--- a/chain/tendermint/tendermint.go
+++ b/chain/tendermint/tendermint.go
@@ -33,7 +33,6 @@ func PrettyPrintTxs(ctx context.Context, txs types.Txs, getTx func(ctx context.C
 	buf := new(bytes.Buffer)
 	for i, tx := range txs {
 		buf.WriteString(fmt.Sprintf("TX %d: ", i))
-		buf.WriteString(tx.String() + "\n")
 
 		// Tx data may contain useful information such as protobuf message type but will be
 		// mixed in with non-human readable data.

--- a/chain/tendermint/tendermint_node.go
+++ b/chain/tendermint/tendermint_node.go
@@ -85,7 +85,6 @@ func (tn *TendermintNode) NewClient(addr string) error {
 
 	tn.Client = rpcClient
 	return nil
-
 }
 
 // Name is the hostname of the test node container

--- a/chain/tendermint/tendermint_test.go
+++ b/chain/tendermint/tendermint_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
+func TestAttributeValue(t *testing.T) {
+	events := []abcitypes.Event{
+		{Type: "1", Attributes: []abcitypes.EventAttribute{
+			{Key: []byte("ignore"), Value: []byte("should not see me")},
+			{Key: []byte("key1"), Value: []byte("found me 1")},
+		}},
+		{Type: "2", Attributes: []abcitypes.EventAttribute{
+			{Key: []byte("key2"), Value: []byte("found me 2")},
+			{Key: []byte("ignore"), Value: []byte("should not see me")},
+		}},
+	}
+
+	_, ok := AttributeValue(nil, "test", nil)
+	require.False(t, ok)
+
+	_, ok = AttributeValue(events, "key_not_there", []byte("ignored"))
+	require.False(t, ok)
+
+	_, ok = AttributeValue(events, "1", []byte("attribute not there"))
+	require.False(t, ok)
+
+	got, ok := AttributeValue(events, "1", []byte("key1"))
+	require.True(t, ok)
+	require.Equal(t, "found me 1", string(got))
+
+	got, ok = AttributeValue(events, "2", []byte("key2"))
+	require.True(t, ok)
+	require.Equal(t, "found me 2", string(got))
+}
+
 func TestPrettyPrintTxs(t *testing.T) {
 	ctx := context.Background()
 

--- a/chain/tendermint/tendermint_test.go
+++ b/chain/tendermint/tendermint_test.go
@@ -1,0 +1,83 @@
+package tendermint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
+	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+type mockClient struct {
+	GotHeight       int64
+	StubResultBlock *coretypes.ResultBlock
+	StubResultTx    *coretypes.ResultTx
+}
+
+func (m *mockClient) Block(ctx context.Context, height *int64) (*coretypes.ResultBlock, error) {
+	m.GotHeight = *height
+	return m.StubResultBlock, nil
+}
+
+func (m *mockClient) Tx(ctx context.Context, hash []byte, prove bool) (*coretypes.ResultTx, error) {
+	return m.StubResultTx, nil
+}
+
+func (m *mockClient) BlockByHash(ctx context.Context, hash []byte) (*coretypes.ResultBlock, error) {
+	panic("implement me")
+}
+
+func (m *mockClient) BlockResults(ctx context.Context, height *int64) (*coretypes.ResultBlockResults, error) {
+	panic("implement me")
+}
+
+func (m *mockClient) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
+	panic("implement me")
+}
+
+func (m *mockClient) Validators(ctx context.Context, height *int64, page, perPage *int) (*coretypes.ResultValidators, error) {
+	panic("implement me")
+}
+
+func (m *mockClient) TxSearch(ctx context.Context, query string, prove bool, page, perPage *int, orderBy string) (*coretypes.ResultTxSearch, error) {
+	panic("implement me")
+}
+
+func (m *mockClient) BlockSearch(ctx context.Context, query string, page, perPage *int, orderBy string) (*coretypes.ResultBlockSearch, error) {
+	panic("implement me")
+}
+
+func TestPrettyPrintBlock(t *testing.T) {
+	client := &mockClient{
+		StubResultBlock: &coretypes.ResultBlock{
+			Block: &types.Block{
+				Data: types.Data{
+					Txs: types.Txs{types.Tx("test")},
+				},
+			},
+		},
+		StubResultTx: &coretypes.ResultTx{
+			TxResult: abcitypes.ResponseDeliverTx{
+				Data: []byte("test data"),
+				Events: []abcitypes.Event{
+					{Type: "event1.type", Attributes: []abcitypes.EventAttribute{
+						{Key: []byte("event1.key"), Value: []byte("event1.value")},
+					}},
+				},
+			},
+		},
+	}
+
+	got, err := PrettyPrintBlock(context.Background(), client, 3)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 3, client.GotHeight)
+	require.NotEmpty(t, got)
+	require.Contains(t, got, "BLOCK 3")
+	require.Contains(t, got, "test")
+	require.Contains(t, got, "event1.type")
+	require.Contains(t, got, "event1.key")
+	require.Contains(t, got, "event1.value")
+}

--- a/ibc/Chain.go
+++ b/ibc/Chain.go
@@ -76,4 +76,7 @@ type Chain interface {
 
 	// fetch transaction
 	GetTransaction(ctx context.Context, txHash string) (*types.TxResponse, error)
+
+	// GetPacketAcknowledgments fetches ibc packet acks
+	GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]PacketAcknowledgment, error)
 }

--- a/ibc/Chain.go
+++ b/ibc/Chain.go
@@ -77,6 +77,9 @@ type Chain interface {
 	// fetch transaction
 	GetTransaction(ctx context.Context, txHash string) (*types.TxResponse, error)
 
-	// GetPacketAcknowledgments fetches ibc packet acks
-	GetPacketAcknowledgments(ctx context.Context, portID, channelID string) ([]PacketAcknowledgment, error)
+	// GetPacketAcknowledgment fetches ibc packet ack or an error if not found
+	GetPacketAcknowledgment(ctx context.Context, portID, channelID string, seq uint64) (PacketAcknowledgment, error)
+
+	// GetPacketSequence returns the packet sequence given the transaction's hash
+	GetPacketSequence(ctx context.Context, txHash string) (uint64, error)
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -66,7 +66,6 @@ const (
 )
 
 type PacketAcknowledgment struct {
-	Data   []byte
-	Height uint64
-	Seq    uint64
+	Data     []byte
+	Sequence uint64
 }

--- a/ibc/types.go
+++ b/ibc/types.go
@@ -64,3 +64,9 @@ const (
 	CosmosRly RelayerImplementation = iota
 	Hermes
 )
+
+type PacketAcknowledgment struct {
+	Data   []byte
+	Height uint64
+	Seq    uint64
+}

--- a/ibctest/log.go
+++ b/ibctest/log.go
@@ -10,12 +10,12 @@ import (
 func CreateLogFile(name string) (*os.File, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("UserHomeDir: %w", err)
+		return nil, fmt.Errorf("user home dir: %w", err)
 	}
 	fpath := filepath.Join(home, ".ibctest", "logs")
 	err = os.MkdirAll(fpath, 0755)
 	if err != nil {
-		return nil, fmt.Errorf("MkdirAll: %w", err)
+		return nil, fmt.Errorf("mkdirall: %w", err)
 	}
 	return os.Create(filepath.Join(fpath, name))
 }

--- a/log/iface.go
+++ b/log/iface.go
@@ -14,4 +14,7 @@ type Logger interface {
 
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
+
+	// Level returns current log level as a lowercased string
+	Level() string
 }

--- a/log/log.go
+++ b/log/log.go
@@ -78,6 +78,10 @@ func (l logger) Errorf(format string, args ...interface{}) {
 	l.sendf(l.logger.Error(), format, args...)
 }
 
+func (l logger) Level() string {
+	return l.logger.GetLevel().String()
+}
+
 func (l logger) send(event *zerolog.Event, args ...interface{}) {
 	event = event.Caller(2)
 	if len(args) == 0 {

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -145,14 +145,11 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 		eg        errgroup.Group
 		txHashSrc string
 		txHashDst string
-
-		srcChannelID = channels[0].ChannelID
-		dstChannelID = channels[0].Counterparty.ChannelID
 	)
 
 	eg.Go(func() error {
 		var err error
-		t.Logf("Sending ibc transfer from %s to %s on channel %s", srcChain.Config().ChainID, dstChain.Config().ChainID, srcChannelID)
+		srcChannelID := channels[0].ChannelID
 		txHashSrc, err = srcChain.SendIBCTransfer(ctx, srcChannelID, srcUser.KeyName, testCoinSrcToDst, timeout)
 		if err != nil {
 			return fmt.Errorf("failed to send ibc transfer from source: %w", err)
@@ -162,7 +159,7 @@ func sendIBCTransfersFromBothChainsWithTimeout(
 
 	eg.Go(func() error {
 		var err error
-		t.Logf("Sending ibc transfer from %s to %s on channel %s", dstChain.Config().ChainID, srcChain.Config().ChainID, dstChannelID)
+		dstChannelID := channels[0].Counterparty.ChannelID
 		txHashDst, err = dstChain.SendIBCTransfer(ctx, dstChannelID, dstUser.KeyName, testCoinDstToSrc, timeout)
 		if err != nil {
 			return fmt.Errorf("failed to send ibc transfer from destination: %w", err)
@@ -273,7 +270,7 @@ func testPacketRelaySuccess(
 	dstChainCfg := dstChain.Config()
 
 	// [BEGIN] assert on source to destination transfer
-	t.Logf("Asserting %s (source) to %s (destination) transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
+	t.Logf("Asserting %s to %s transfer", srcChainCfg.ChainID, dstChainCfg.ChainID)
 	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now
 	srcInitialBalance := userFaucetFund
 	dstInitialBalance := int64(0)
@@ -305,7 +302,7 @@ func testPacketRelaySuccess(
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
-	t.Logf("Asserting %s (destination) to %s (source) transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
+	t.Logf("Asserting %s to %s transfer", dstChainCfg.ChainID, srcChainCfg.ChainID)
 	dstUser := testCase.Users[1]
 	dstDenom := dstChainCfg.Denom
 	// Assuming these values since the ibc transfers were sent in PreRelayerStart, so balances may have already changed by now

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -296,9 +296,11 @@ func testPacketRelaySuccess(
 	require.Equal(t, srcInitialBalance-expectedDifference, srcFinalBalance)
 	require.Equal(t, dstInitialBalance+testCoinAmount, dstFinalBalance)
 
-	srcAcks, err := srcChain.GetPacketAcknowledgments(ctx, "transfer", "channel-0")
+	seq, err := srcChain.GetPacketSequence(ctx, srcTxHash)
 	require.NoError(t, err)
-	require.NotEmpty(t, srcAcks)
+	_, err = srcChain.GetPacketAcknowledgment(ctx, channels[0].PortID, channels[0].ChannelID, seq)
+	require.NoError(t, err)
+
 	// [END] assert on source to destination transfer
 
 	// [BEGIN] assert on destination to source transfer
@@ -329,9 +331,10 @@ func testPacketRelaySuccess(
 	require.Equal(t, srcInitialBalance+testCoinAmount, srcFinalBalance)
 	require.Equal(t, dstInitialBalance-expectedDifference, dstFinalBalance)
 
-	dstAcks, err := dstChain.GetPacketAcknowledgments(ctx, "transfer", "channel-0")
+	seq, err = dstChain.GetPacketSequence(ctx, dstTxHash)
 	require.NoError(t, err)
-	require.NotEmpty(t, dstAcks)
+	_, err = dstChain.GetPacketAcknowledgment(ctx, channels[0].PortID, channels[0].ChannelID, seq)
+	require.NoError(t, err)
 
 	//[END] assert on destination to source transfer
 }


### PR DESCRIPTION
# Description, Motivation, and Context

Attempt to make meaningful assertions against IBC transactions and the followup acknowledgement transaction.

## Addiionally

When `debug` logs activated, prints tendermint block details for cosmos chains.

## Known Limitations, Trade-offs, Tech Debt
* Bloats the `ibc.Chain` interface even more. 
* `WaitForBlocks` may be able to move toward `WaitForAck(seq uint64)` or similar. That may be explored in a future PR.