### PR TITLE
Add Name() method to relayer and chain factories

### DIFF
--- a/cmd/ibctest/ibctest_test.go
+++ b/cmd/ibctest/ibctest_test.go
@@ -149,7 +149,7 @@ func TestRelayer(t *testing.T) {
 			panic(err)
 		}
 
-		t.Run(r, func(t *testing.T) {
+		t.Run(rf.Name(), func(t *testing.T) {
 			t.Parallel()
 
 			// Collect all the chain factories from both the builtins and the customs.
@@ -170,19 +170,7 @@ func TestRelayer(t *testing.T) {
 			}
 
 			for _, cf := range chainFactories {
-				// As of writing, it's fine to build a chain pair just to inspect names and versions.
-				srcChain, dstChain, err := cf.Pair("")
-				if err != nil {
-					panic(err)
-				}
-
-				chainTestName := fmt.Sprintf(
-					"%s@%s+%s@%s",
-					srcChain.Config().Name, srcChain.Config().Images[0].Version,
-					dstChain.Config().Name, dstChain.Config().Images[0].Version,
-				)
-
-				t.Run(chainTestName, func(t *testing.T) {
+				t.Run(cf.Name(), func(t *testing.T) {
 					t.Parallel()
 
 					// Finally, the relayertest suite.

--- a/ibctest/chainfactory.go
+++ b/ibctest/chainfactory.go
@@ -2,6 +2,7 @@ package ibctest
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/strangelove-ventures/ibc-test-framework/chain/penumbra"
 	"go.uber.org/zap"
@@ -16,6 +17,12 @@ import (
 type ChainFactory interface {
 	// Pair returns two chains for IBC.
 	Pair(testName string) (ibc.Chain, ibc.Chain, error)
+
+	// Name returns a descriptive name of the factory,
+	// indicating all of its chains.
+	// Depending on how the factory was configured,
+	// this may report more than two chains.
+	Name() string
 }
 
 // BuiltinChainFactory implements ChainFactory to return a fixed set of chains.
@@ -71,6 +78,14 @@ func (f *BuiltinChainFactory) Pair(testName string) (ibc.Chain, ibc.Chain, error
 // Returns all chains
 func (f *BuiltinChainFactory) GetAllChains(testName string) ([]ibc.Chain, error) {
 	return f.GetChains(testName, -1)
+}
+
+func (f *BuiltinChainFactory) Name() string {
+	parts := make([]string, len(f.entries))
+	for i, e := range f.entries {
+		parts[i] = e.Name + "@" + e.Version
+	}
+	return strings.Join(parts, "+")
 }
 
 // CustomChainFactory is a ChainFactory that supports returning chains that are defined by ChainConfig values.
@@ -133,4 +148,12 @@ func (f *CustomChainFactory) Pair(testName string) (ibc.Chain, ibc.Chain, error)
 // Returns all chains
 func (f *CustomChainFactory) GetAllChains(testName string) ([]ibc.Chain, error) {
 	return f.GetChains(testName, -1)
+}
+
+func (f *CustomChainFactory) Name() string {
+	parts := make([]string, len(f.entries))
+	for i, e := range f.entries {
+		parts[i] = e.Config.Name + "@" + e.Config.Images[0].Version
+	}
+	return strings.Join(parts, "+")
 }

--- a/ibctest/relayerfactory.go
+++ b/ibctest/relayerfactory.go
@@ -21,6 +21,10 @@ type RelayerFactory interface {
 		home string,
 	) ibc.Relayer
 
+	// Name returns a descriptive name of the factory,
+	// indicating details of the Relayer that will be built.
+	Name() string
+
 	// Capabilities is an indication of the features this relayer supports.
 	// Tests for any unsupported features will be skipped rather than failed.
 	Capabilities() map[relayer.Capability]bool
@@ -58,6 +62,18 @@ func (f builtinRelayerFactory) Build(
 			home,
 			f.log,
 		)
+	default:
+		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
+	}
+}
+
+func (f builtinRelayerFactory) Name() string {
+	switch f.impl {
+	case ibc.CosmosRly:
+		// This is using the string "rly" instead of rly.ContainerImage
+		// so that the slashes in the image repository don't add ambiguity
+		// to subtest paths, when the factory name is used in calls to t.Run.
+		return "rly@" + rly.ContainerVersion
 	default:
 		panic(fmt.Errorf("RelayerImplementation %v unknown", f.impl))
 	}

--- a/relayer/rly/cosmos_relayer.go
+++ b/relayer/rly/cosmos_relayer.go
@@ -50,8 +50,8 @@ type CosmosRelayerChainConfig struct {
 }
 
 const (
-	containerImage   = "ghcr.io/cosmos/relayer"
-	containerVersion = "v2.0.0-beta4"
+	ContainerImage   = "ghcr.io/cosmos/relayer"
+	ContainerVersion = "v2.0.0-beta4"
 )
 
 // Capabilities returns the set of capabilities of the Cosmos relayer.
@@ -90,7 +90,7 @@ func NewCosmosRelayerFromChains(t *testing.T, pool *dockertest.Pool, networkID s
 		networkID: networkID,
 		home:      home,
 		testName:  t.Name(),
-		log:       logger.With(zap.String("test", t.Name()), zap.String("image", containerImage+":"+containerVersion)),
+		log:       logger.With(zap.String("test", t.Name()), zap.String("image", ContainerImage+":"+ContainerVersion)),
 	}
 	rly.MkDir()
 	return rly
@@ -216,8 +216,8 @@ func (relayer *CosmosRelayer) UpdateClients(ctx context.Context, pathName string
 
 func (relayer *CosmosRelayer) CreateNodeContainer(pathName string) error {
 	err := relayer.pool.Client.PullImage(docker.PullImageOptions{
-		Repository: containerImage,
-		Tag:        containerVersion,
+		Repository: ContainerImage,
+		Tag:        ContainerVersion,
 	}, docker.AuthConfiguration{})
 	if err != nil {
 		return err
@@ -235,7 +235,7 @@ func (relayer *CosmosRelayer) CreateNodeContainer(pathName string) error {
 			Cmd:        cmd,
 			Entrypoint: []string{},
 			Hostname:   relayer.HostName(pathName),
-			Image:      fmt.Sprintf("%s:%s", containerImage, containerVersion),
+			Image:      fmt.Sprintf("%s:%s", ContainerImage, ContainerVersion),
 			Labels:     map[string]string{"ibc-test": relayer.testName},
 		},
 		NetworkingConfig: &docker.NetworkingConfig{
@@ -259,8 +259,8 @@ func (relayer *CosmosRelayer) CreateNodeContainer(pathName string) error {
 // NOTE: on job containers generate random name
 func (relayer *CosmosRelayer) NodeJob(ctx context.Context, cmd []string) (int, string, string, error) {
 	err := relayer.pool.Client.PullImage(docker.PullImageOptions{
-		Repository: containerImage,
-		Tag:        containerVersion,
+		Repository: ContainerImage,
+		Tag:        ContainerVersion,
 	}, docker.AuthConfiguration{})
 	if err != nil {
 		return 1, "", "", err
@@ -281,7 +281,7 @@ func (relayer *CosmosRelayer) NodeJob(ctx context.Context, cmd []string) (int, s
 			User: dockerutil.GetDockerUserString(),
 			// random hostname is fine here, just for setup
 			Hostname:   dockerutil.CondenseHostName(container),
-			Image:      fmt.Sprintf("%s:%s", containerImage, containerVersion),
+			Image:      fmt.Sprintf("%s:%s", ContainerImage, ContainerVersion),
 			Cmd:        cmd,
 			Entrypoint: []string{},
 			Labels:     map[string]string{"ibc-test": relayer.testName},


### PR DESCRIPTION
This moves the name generation logic into the factory, where it belongs,
instead of in the test generation logic.

This will also assist in producing additional reports about test
results.