### PR TITLE
Add initial test reporter

### DIFF
--- a/cmd/ibctest/flags.go
+++ b/cmd/ibctest/flags.go
@@ -17,6 +17,7 @@ type mainFlags struct {
 	LogFormat  string
 	LogLevel   string
 	MatrixFile string
+	ReportFile string
 }
 
 func (f mainFlags) Logger() (lc LoggerCloser, _ error) {

--- a/testreporter/doc.go
+++ b/testreporter/doc.go
@@ -1,0 +1,64 @@
+// Package testreporter contains a Reporter for collecting detailed test reports.
+//
+// While you could probably get at all of the exposed information in reports
+// by examining the output of "go test",
+// the generated report is intended to collect the information in one machine-readable file.
+//
+// Proper use of the reporter requires some slight changes to how you normally write tests.
+// If you do any of these "the normal way", the tests will still operate fine;
+// you will just miss some detail in the external report.
+//
+// First, the reporter instance must be initialized and Closed.
+// The cmd/ibctest package does this in a MainTest function, similar to this:
+//     func TestMain(m *testing.M) {
+//       f, _ := os.Create("/tmp/report.json")
+//       reporter := testreporter.NewReporter(f)
+//       code := m.Run()
+//       _ = reporter.Close()
+//       os.Exit(code)
+//     }
+//
+// Next, every test that needs to be tracked must call TrackTest.
+// If you omit the call to TrackTest, then the test's start and end time,
+// and skip/fail status, will not be reported.
+//
+//     var reporter *testreporter.Reporter // Initialized somehow.
+//
+//     func TestFoo(t *testing.T) {
+//       reporter.TrackTest(t)
+//       // Normal test usage continues...
+//     }
+//
+// Calling TrackTest tracks the test's start and finish time,
+// including whether the test was skipped or failed.
+//
+// Parallel tests should not call t.Parallel directly,
+// but instead should use TrackParallel.
+// This will track the time the test paused waiting for parallel execution
+// and when parallel execution resumes.
+// If you omit the call to TrackParallel, then at worst you have a misleading test duration.
+//
+//     func TestFooParallel(t *testing.T) {
+//       reporter.TrackTest(t)
+//       reporter.TrackParallel(t)
+//       // Normal test usage continues...
+//     }
+//
+// Lastly, and perhaps most importantly, the reporter is designed to integrate
+// with testify's require and assert packages.
+// Plain "go test" runs simply have a stream of log lines and a failure/skip state.
+// But if you connect the reporter with a require or assert instance,
+// any failed assertions are stored as error messages in the report.
+//
+//     func TestBar(t *testing.T) {
+//       reporter.TrackTest(t)
+//       req := require.New(reporter.TestifyT(t))
+//       t.Log("About to test Bar()") // Goes to "go test" output, but not included in report.
+//
+//       // If this fails, the report includes a "TestErrorMessage" entry in the report.
+//       req.NoError(Bar(), "failure executing Bar()")
+//     }
+//
+// If you use a plain require.NoError(t, err) call,
+// the report will note that the test failed, but the report will not include the error line.
+package testreporter

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -1,0 +1,47 @@
+package testreporter
+
+import "time"
+
+type Message interface {
+	typ() string
+}
+
+type BeginSuiteMessage struct {
+	StartedAt time.Time
+
+	// TODO: it would be nice to embed the ibc-test-framework commit in this message,
+	// but while https://github.com/golang/go/issues/33976 is outstanding,
+	// we'll have to fall back to ldflags to embed it.
+}
+
+func (m BeginSuiteMessage) typ() string {
+	return "BeginSuite"
+}
+
+type FinishSuiteMessage struct {
+	FinishedAt time.Time
+}
+
+func (m FinishSuiteMessage) typ() string {
+	return "FinishSuite"
+}
+
+type BeginTestMessage struct {
+	Name      string
+	StartedAt time.Time
+}
+
+func (m BeginTestMessage) typ() string {
+	return "BeginTest"
+}
+
+type FinishTestMessage struct {
+	Name       string
+	FinishedAt time.Time
+
+	Failed, Skipped bool
+}
+
+func (m FinishTestMessage) typ() string {
+	return "FinishTest"
+}

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -50,6 +50,24 @@ func (m FinishTestMessage) typ() string {
 	return "FinishTest"
 }
 
+type PauseTestMessage struct {
+	Name string
+	When time.Time
+}
+
+func (m PauseTestMessage) typ() string {
+	return "PauseTest"
+}
+
+type ContinueTestMessage struct {
+	Name string
+	When time.Time
+}
+
+func (m ContinueTestMessage) typ() string {
+	return "ContinueTest"
+}
+
 type TestErrorMessage struct {
 	Name    string
 	When    time.Time
@@ -101,6 +119,14 @@ func (m *WrappedMessage) UnmarshalJSON(b []byte) error {
 		msg = x
 	case "FinishTest":
 		x := FinishTestMessage{}
+		err = json.Unmarshal(raw, &x)
+		msg = x
+	case "PauseTest":
+		x := PauseTestMessage{}
+		err = json.Unmarshal(raw, &x)
+		msg = x
+	case "ContinueTest":
+		x := ContinueTestMessage{}
 		err = json.Unmarshal(raw, &x)
 		msg = x
 	case "TestError":

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -17,6 +17,8 @@ func TestWrappedMessage_RoundTrip(t *testing.T) {
 		{Message: testreporter.BeginSuiteMessage{StartedAt: time.Now()}},
 		{Message: testreporter.FinishSuiteMessage{FinishedAt: time.Now()}},
 		{Message: testreporter.BeginTestMessage{Name: "foo", StartedAt: time.Now()}},
+		{Message: testreporter.PauseTestMessage{Name: "foo", When: time.Now()}},
+		{Message: testreporter.ContinueTestMessage{Name: "foo", When: time.Now()}},
 		{Message: testreporter.FinishTestMessage{Name: "foo", FinishedAt: time.Now(), Skipped: true, Failed: true}},
 		{Message: testreporter.TestErrorMessage{Name: "foo", When: time.Now(), Message: "something failed"}},
 	}

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -1,0 +1,36 @@
+package testreporter_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/strangelove-ventures/ibc-test-framework/testreporter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrappedMessage_RoundTrip(t *testing.T) {
+	tcs := []struct {
+		Message testreporter.Message
+	}{
+		{Message: testreporter.BeginSuiteMessage{StartedAt: time.Now()}},
+		{Message: testreporter.FinishSuiteMessage{FinishedAt: time.Now()}},
+		{Message: testreporter.BeginTestMessage{Name: "foo", StartedAt: time.Now()}},
+		{Message: testreporter.FinishTestMessage{Name: "foo", FinishedAt: time.Now(), Skipped: true, Failed: true}},
+		{Message: testreporter.TestErrorMessage{Name: "foo", When: time.Now(), Message: "something failed"}},
+	}
+
+	for _, tc := range tcs {
+		wrapped := testreporter.JSONMessage(tc.Message)
+
+		out, err := json.Marshal(wrapped)
+		require.NoError(t, err)
+
+		var unwrapped testreporter.WrappedMessage
+		require.NoError(t, json.Unmarshal(out, &unwrapped))
+
+		diff := cmp.Diff(wrapped, unwrapped)
+		require.Empty(t, diff)
+	}
+}

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -1,0 +1,93 @@
+// Package testreporter contains a Reporter for collecting detailed test reports.
+package testreporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// T is a subset of testing.TB,
+// representing only the methods required by the reporter.
+type T interface {
+	Name() string
+	Cleanup(func())
+
+	Failed() bool
+	Skipped() bool
+}
+
+type Reporter struct {
+	w io.WriteCloser
+
+	in chan Message
+
+	writerDone chan error
+}
+
+func NewReporter(w io.WriteCloser) *Reporter {
+	r := &Reporter{
+		w: w,
+
+		in:         make(chan Message, 256), // Arbitrary size that seems unlikely to be filled.
+		writerDone: make(chan error, 1),
+	}
+
+	go r.write()
+	r.in <- BeginSuiteMessage{StartedAt: time.Now()}
+
+	return r
+}
+
+// write runs in its own goroutine to continually output reporting messages.
+func (r *Reporter) write() {
+	enc := json.NewEncoder(r.w)
+	enc.SetEscapeHTML(false)
+
+	for m := range r.in {
+		// Encode the message with an outer type field,
+		// so decoders can inspect the type and decide how to unmarshal.
+		j := struct {
+			Type string
+			Message
+		}{
+			Type:    m.typ(),
+			Message: m,
+		}
+		if err := enc.Encode(j); err != nil {
+			panic(fmt.Errorf("reporter failed to encode message; tests cannot continue: %w", err))
+		}
+	}
+
+	// Before closing the writer
+	r.writerDone <- r.w.Close()
+}
+
+// Close closes the reporter and blocks until its results are flushed
+// to the underlying writer.
+func (r *Reporter) Close() error {
+	r.in <- FinishSuiteMessage{
+		FinishedAt: time.Now(),
+	}
+	close(r.in)
+	return <-r.writerDone
+}
+
+// TrackTest tracks the test start and finish time.
+func (r *Reporter) TrackTest(t T) {
+	name := t.Name()
+	r.in <- BeginTestMessage{
+		Name:      name,
+		StartedAt: time.Now(),
+	}
+	t.Cleanup(func() {
+		r.in <- FinishTestMessage{
+			Name:       name,
+			FinishedAt: time.Now(),
+
+			Failed:  t.Failed(),
+			Skipped: t.Skipped(),
+		}
+	})
+}

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -14,6 +14,8 @@ type T interface {
 	Name() string
 	Cleanup(func())
 
+	Parallel()
+
 	Failed() bool
 	Skipped() bool
 }
@@ -82,6 +84,21 @@ func (r *Reporter) TrackTest(t T) {
 			Skipped: t.Skipped(),
 		}
 	})
+}
+
+// TrackParallel tracks when the pause begins for a parallel test
+// and when it continues to resume.
+func (r *Reporter) TrackParallel(t T) {
+	name := t.Name()
+	r.in <- PauseTestMessage{
+		Name: name,
+		When: time.Now(),
+	}
+	t.Parallel()
+	r.in <- ContinueTestMessage{
+		Name: name,
+		When: time.Now(),
+	}
 }
 
 // TestifyT returns a TestifyReporter which will track logged errors in test.

--- a/testreporter/reporter.go
+++ b/testreporter/reporter.go
@@ -1,4 +1,3 @@
-// Package testreporter contains a Reporter for collecting detailed test reports.
 package testreporter
 
 import (


### PR DESCRIPTION
This PR is the first step towards producing machine-readable test reports.

The `ibctest` executable now emits a report, defaulting to `~/.ibctest/reports/$UNIX_TIMESTAMP_NOW.json`, that is a file containing a stream of JSON objects representing test events that would be relevant to produce a human-readable report.

Internally, this introduces a `testreporter` package with a `*Reporter` type, which is used additively during plain Go tests to collect details at an individual test level in a machine-readable JSON format. See `testreporter/doc.go` for a thorough explanation of how to use the reporter.

As of this PR, the reporter tracks suite start and end times, and individual start/stop times along with skip and fail status -- which is roughly parity with the plain output from Go test. 

However, there is one additional relevant feature of the reporter, which is its integration with testify `require` and `assert`. An instance of `require` can be created in a test with `req := require.New(reporter.TestifyT(t))`, and then any failed calls such as `req.NoError(err, "failure to foo")` will be logged to the plain `go test` output as usual, but it will also record an entry in the report log. This way, we can not only present the fact that a test failed, but we can also note the exact error message that was logged as the failure.

The two significant remaining pieces of work for the test reporter are:
1. Include output from relayer executions, to allow drilling in to failures or investigating timing outliers. Not included in this PR because it will be a decent size change.
2. Integrate skip messages with the reporter. While the reporter can see that a test _was_ skipped, it does not have insight into the specific message passed to `t.Skip`. While I could have just added a wrapper for that, we have multiple reasons that a test may be skipped, including a missing relayer capability or filtering by including or excluding labels for tests.

I expect that the information we include in the report will expand over time. We may eventually want to include the chain logs, for instance. We may have more application-specific details to log, such as block-level information.