### PR TITLE
fix: Ensure skipped tests are not omitted

### DIFF
--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -193,6 +193,7 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 		testCases = append(testCases, &testCase)
 
 		if len(missingCapabilities(rf, testCaseConfig.RequiredRelayerCapabilities...)) > 0 {
+			// do not execute relayer before hook if capability missing
 			continue
 		}
 		preRelayerStartFunc := func(channels []ibc.ChannelOutput) {

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -104,7 +104,7 @@ func requireCapabilities(t *testing.T, rf ibctest.RelayerFactory, reqCaps ...rel
 
 func missingCapabilities(rf ibctest.RelayerFactory, reqCaps ...relayer.Capability) []relayer.Capability {
 	caps := rf.Capabilities()
-	missing := []relayer.Capability{}
+	var missing []relayer.Capability
 	for _, c := range reqCaps {
 		if !caps[c] {
 			missing = append(missing, c)
@@ -187,15 +187,15 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	)
 
 	for _, testCaseConfig := range relayerTestCaseConfigs {
-		if len(missingCapabilities(rf, testCaseConfig.RequiredRelayerCapabilities...)) > 0 {
-			continue
-		}
 		testCase := RelayerTestCase{
 			Config: testCaseConfig,
 		}
 		testCases = append(testCases, &testCase)
-		preRelayerStartFunc := func(channels []ibc.ChannelOutput) {
 
+		if len(missingCapabilities(rf, testCaseConfig.RequiredRelayerCapabilities...)) > 0 {
+			continue
+		}
+		preRelayerStartFunc := func(channels []ibc.ChannelOutput) {
 			// fund a user wallet on both chains, save on test case
 			testCase.Users = ibctest.GetAndFundTestUsers(t, ctx, strings.ReplaceAll(testCase.Config.Name, " ", "-"), userFaucetFund, srcChain, dstChain)
 			// run test specific pre relayer start action
@@ -248,7 +248,7 @@ func preRelayerStart_HeightTimeout(ctx context.Context, t *testing.T, testCase *
 }
 
 func preRelayerStart_TimestampTimeout(ctx context.Context, t *testing.T, testCase *RelayerTestCase, srcChain ibc.Chain, dstChain ibc.Chain, channels []ibc.ChannelOutput) {
-	ibcTimeoutTimestamp := ibc.IBCTimeout{NanoSeconds: uint64((10 * time.Second).Nanoseconds())}
+	ibcTimeoutTimestamp := ibc.IBCTimeout{NanoSeconds: uint64((1 * time.Second).Nanoseconds())}
 	sendIBCTransfersFromBothChainsWithTimeout(ctx, t, testCase, srcChain, dstChain, channels, &ibcTimeoutTimestamp)
 	// wait for 15 seconds to expire timeout
 	time.Sleep(15 * time.Second)

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -193,7 +193,8 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 		testCases = append(testCases, &testCase)
 
 		if len(missingCapabilities(rf, testCaseConfig.RequiredRelayerCapabilities...)) > 0 {
-			// do not execute relayer before hook if capability missing
+			// Do not add preRelayerStartFunc if capability missing.
+			// Adding all preRelayerStartFuncs appears to cause test pollution which is why this step is necessary.
 			continue
 		}
 		preRelayerStartFunc := func(channels []ibc.ChannelOutput) {


### PR DESCRIPTION
In attempting to test acknowledgements for `height timeout` and `timestamp timeout` scenarios, I discovered `timestamp` always passed and `height` always failed.

But what was really happening was `timestamp timeout` is not a capability of the go relayer `rly`. 

We were inadvertently omitting the test entirely. Therefore, unless you looked closely, it appears as if the test passes, when in fact, it wasn't run at all. 

This PR fixes the above issue, so you will explicity see `SKIP` in the test output like so:

<img width="770" alt="Screen Shot 2022-05-12 at 4 32 38 PM" src="https://user-images.githubusercontent.com/224251/168180482-9dbed123-e464-47c9-b524-e065c782770b.png">

