### PR TITLE
Add relayer executions to test report

### DIFF
--- a/ibc/Relayer.go
+++ b/ibc/Relayer.go
@@ -2,36 +2,82 @@ package ibc
 
 import (
 	"context"
+	"time"
 )
 
+// Relayer represents an instance of a relayer that can be support IBC.
+// Built-in implementations are run through Docker,
+// but they could exec out to external processes
+// or even be implemented in-process in Go.
+//
+// All of the methods on Relayer accept a RelayerExecReporter.
+// It is intended that Relayer implementations will call the reporters' TrackRelayerExec method
+// so that details of the relayer execution are included in the test report.
+//
+// If a relayer does not properly call into the reporter,
+// the tests will still execute properly,
+// but the report will be missing details.
 type Relayer interface {
 	// restore a mnemonic to be used as a relayer wallet for a chain
-	RestoreKey(ctx context.Context, chainID, keyName, mnemonic string) error
+	RestoreKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName, mnemonic string) error
 
 	// generate a new key
-	AddKey(ctx context.Context, chainID, keyName string) (RelayerWallet, error)
+	AddKey(ctx context.Context, rep RelayerExecReporter, chainID, keyName string) (RelayerWallet, error)
 
 	// add relayer configuration for a chain
-	AddChainConfiguration(ctx context.Context, chainConfig ChainConfig, keyName, rpcAddr, grpcAddr string) error
+	AddChainConfiguration(ctx context.Context, rep RelayerExecReporter, chainConfig ChainConfig, keyName, rpcAddr, grpcAddr string) error
 
 	// generate new path between two chains
-	GeneratePath(ctx context.Context, srcChainID, dstChainID, pathName string) error
+	GeneratePath(ctx context.Context, rep RelayerExecReporter, srcChainID, dstChainID, pathName string) error
 
 	// setup channels, connections, and clients
-	LinkPath(ctx context.Context, pathName string) error
+	LinkPath(ctx context.Context, rep RelayerExecReporter, pathName string) error
 
 	// update clients, such as after new genesis
-	UpdateClients(ctx context.Context, pathName string) error
+	UpdateClients(ctx context.Context, rep RelayerExecReporter, pathName string) error
 
 	// get channel IDs for chain
-	GetChannels(ctx context.Context, chainID string) ([]ChannelOutput, error)
+	GetChannels(ctx context.Context, rep RelayerExecReporter, chainID string) ([]ChannelOutput, error)
 
-	// after configuration is initialized, begin relaying
-	StartRelayer(ctx context.Context, pathName string) error
+	// After configuration is initialized, begin relaying.
+	// This method is intended to create a background worker that runs the relayer.
+	// You must call StopRelayer to cleanly stop the relaying.
+	StartRelayer(ctx context.Context, rep RelayerExecReporter, pathName string) error
+
+	// StopRelayer stops a relayer that started work through StartRelayer.
+	StopRelayer(ctx context.Context, rep RelayerExecReporter) error
 
 	// relay queue until it is empty
-	ClearQueue(ctx context.Context, pathName string, channelID string) error
+	ClearQueue(ctx context.Context, rep RelayerExecReporter, pathName string, channelID string) error
+}
 
-	// shutdown relayer
-	StopRelayer(ctx context.Context) error
+// ExecReporter is the interface of a narrow type returned by testreporter.RelayerExecReporter.
+// This avoids a direct dependency on the testreporter package,
+// and it avoids the relayer needing to be aware of a *testing.T.
+type RelayerExecReporter interface {
+	TrackRelayerExec(
+		// The name of the docker container in which this relayer command executed,
+		// or empty if it did not run in docker.
+		containerName string,
+
+		// The command line passed to this invocation of the relayer.
+		command []string,
+
+		// The standard output and standard error that the relayer produced during this invocation.
+		stdout, stderr string,
+
+		// The exit code of executing the command.
+		// This field may not be applicable for e.g. an in-process relayer implementation.
+		exitCode int,
+
+		// When the command started and finished.
+		startedAt, finishedAt time.Time,
+
+		// Any error that occurred during execution.
+		// This indicates a failure to execute,
+		// e.g. the relayer binary not being found, failure communicating with Docker, etc.
+		// If the process completed with a non-zero exit code,
+		// those details should be indicated between stdout, stderr, and exitCode.
+		err error,
+	)
 }

--- a/ibctest/test_setup.go
+++ b/ibctest/test_setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/strangelove-ventures/ibc-test-framework/dockerutil"
 	"github.com/strangelove-ventures/ibc-test-framework/ibc"
+	"github.com/strangelove-ventures/ibc-test-framework/testreporter"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -59,6 +60,7 @@ func SetupTestRun(t *testing.T) (context.Context, string, *dockertest.Pool, stri
 func StartChainsAndRelayerFromFactory(
 	t *testing.T,
 	ctx context.Context,
+	rep *testreporter.Reporter,
 	pool *dockertest.Pool,
 	networkID string,
 	home string,
@@ -187,7 +189,10 @@ func StartChainsAndRelayerFromFactory(
 		dstRPCAddr, dstGRPCAddr = dstChain.GetHostRPCAddress(), dstChain.GetHostGRPCAddress()
 	}
 
+	eRep := rep.RelayerExecReporter(t)
+
 	if err := relayerImpl.AddChainConfiguration(ctx,
+		eRep,
 		srcChainCfg, srcAccountKeyName,
 		srcRPCAddr, srcGRPCAddr,
 	); err != nil {
@@ -195,28 +200,29 @@ func StartChainsAndRelayerFromFactory(
 	}
 
 	if err := relayerImpl.AddChainConfiguration(ctx,
+		eRep,
 		dstChainCfg, dstAccountKeyName,
 		dstRPCAddr, dstGRPCAddr,
 	); err != nil {
 		return errResponse(fmt.Errorf("failed to configure relayer for dest chain: %w", err))
 	}
 
-	if err := relayerImpl.RestoreKey(ctx, srcChain.Config().ChainID, srcAccountKeyName, srcMnemonic); err != nil {
+	if err := relayerImpl.RestoreKey(ctx, eRep, srcChain.Config().ChainID, srcAccountKeyName, srcMnemonic); err != nil {
 		return errResponse(fmt.Errorf("failed to restore key to source chain: %w", err))
 	}
-	if err := relayerImpl.RestoreKey(ctx, dstChain.Config().ChainID, dstAccountKeyName, dstMnemonic); err != nil {
+	if err := relayerImpl.RestoreKey(ctx, eRep, dstChain.Config().ChainID, dstAccountKeyName, dstMnemonic); err != nil {
 		return errResponse(fmt.Errorf("failed to restore key to dest chain: %w", err))
 	}
 
-	if err := relayerImpl.GeneratePath(ctx, srcChainCfg.ChainID, dstChainCfg.ChainID, testPathName); err != nil {
+	if err := relayerImpl.GeneratePath(ctx, eRep, srcChainCfg.ChainID, dstChainCfg.ChainID, testPathName); err != nil {
 		return errResponse(fmt.Errorf("failed to generate path: %w", err))
 	}
 
-	if err := relayerImpl.LinkPath(ctx, testPathName); err != nil {
+	if err := relayerImpl.LinkPath(ctx, eRep, testPathName); err != nil {
 		return errResponse(fmt.Errorf("failed to create link in relayer: %w", err))
 	}
 
-	channels, err := relayerImpl.GetChannels(ctx, srcChainCfg.ChainID)
+	channels, err := relayerImpl.GetChannels(ctx, eRep, srcChainCfg.ChainID)
 	if err != nil {
 		return errResponse(fmt.Errorf("failed to get channels: %w", err))
 	}
@@ -238,11 +244,11 @@ func StartChainsAndRelayerFromFactory(
 	}
 	wg.Wait()
 
-	if err := relayerImpl.StartRelayer(ctx, testPathName); err != nil {
+	if err := relayerImpl.StartRelayer(ctx, eRep, testPathName); err != nil {
 		return errResponse(fmt.Errorf("failed to start relayer: %w", err))
 	}
 	t.Cleanup(func() {
-		if err := relayerImpl.StopRelayer(ctx); err != nil {
+		if err := relayerImpl.StopRelayer(ctx, eRep); err != nil {
 			t.Logf("error stopping relayer: %v", err)
 		}
 	})

--- a/relayertest/test.go
+++ b/relayertest/test.go
@@ -215,7 +215,7 @@ func TestRelayer(t *testing.T, cf ibctest.ChainFactory, rf ibctest.RelayerFactor
 	// funds relayer src and dst wallets on respective chain in genesis
 	// creates a faucet account on the both chains (separate fullnode)
 	// funds faucet accounts in genesis
-	_, channels, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
+	_, channels, err := ibctest.StartChainsAndRelayerFromFactory(t, ctx, rep, pool, network, home, srcChain, dstChain, rf, preRelayerStartFuncs)
 	req.NoError(err, "failed to StartChainsAndRelayerFromFactory")
 
 	// TODO poll for acks inside of each testCase `.Config.Test` method instead of just waiting for blocks here

--- a/testreporter/messages.go
+++ b/testreporter/messages.go
@@ -96,6 +96,29 @@ func (m TestErrorMessage) typ() string {
 	return "TestError"
 }
 
+// RelayerExecMessage is the result of executing a relayer command.
+// This message is populated through the RelayerExecReporter type,
+// which is returned by the Reporter's RelayerExecReporter method.
+type RelayerExecMessage struct {
+	Name string // Test name, but "Name" for consistency.
+
+	StartedAt, FinishedAt time.Time
+
+	ContainerName string `json:",omitempty"`
+
+	Command []string
+
+	Stdout, Stderr string
+
+	ExitCode int
+
+	Error string `json:",omitempty"`
+}
+
+func (m RelayerExecMessage) typ() string {
+	return "RelayerExec"
+}
+
 // WrappedMessage wraps a Message with an outer Type field
 // so that decoders can determine the underlying message's type.
 type WrappedMessage struct {
@@ -152,6 +175,10 @@ func (m *WrappedMessage) UnmarshalJSON(b []byte) error {
 		msg = x
 	case "TestError":
 		x := TestErrorMessage{}
+		err = json.Unmarshal(raw, &x)
+		msg = x
+	case "RelayerExec":
+		x := RelayerExecMessage{}
 		err = json.Unmarshal(raw, &x)
 		msg = x
 	default:

--- a/testreporter/messages_test.go
+++ b/testreporter/messages_test.go
@@ -21,6 +21,18 @@ func TestWrappedMessage_RoundTrip(t *testing.T) {
 		{Message: testreporter.ContinueTestMessage{Name: "foo", When: time.Now()}},
 		{Message: testreporter.FinishTestMessage{Name: "foo", FinishedAt: time.Now(), Skipped: true, Failed: true}},
 		{Message: testreporter.TestErrorMessage{Name: "foo", When: time.Now(), Message: "something failed"}},
+		{
+			Message: testreporter.RelayerExecMessage{
+				Name:          "foo",
+				StartedAt:     time.Now(),
+				FinishedAt:    time.Now().Add(time.Second),
+				ContainerName: "relayer-exec-123",
+				Command:       []string{"rly", "version"},
+				Stdout:        "relayer v1.2.3",
+				ExitCode:      0,
+				Error:         "",
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/testreporter/reporter_test.go
+++ b/testreporter/reporter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/strangelove-ventures/ibc-test-framework/testreporter"
 	"github.com/stretchr/testify/require"
 )
@@ -221,6 +222,48 @@ func TestReporter_Errorf(t *testing.T) {
 	require.NoError(t, r.Close())
 
 	require.Equal(t, mt.errorfs, []string{"failed? true"})
+}
+
+func TestReporter_RelayerExec(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	r := testreporter.NewReporter(nopCloser{Writer: buf})
+
+	mt := &mockT{name: "my_test"}
+
+	r.TrackTest(mt)
+
+	execStartedAt := time.Now()
+	execFinishedAt := execStartedAt.Add(time.Second)
+	r.RelayerExecReporter(mt).TrackRelayerExec(
+		"my_container",
+		[]string{"rly", "fake_command"},
+		"stdout", "stderr",
+		1,
+		execStartedAt, execFinishedAt,
+		nil,
+	)
+
+	mt.RunCleanups()
+
+	require.NoError(t, r.Close())
+
+	msgs := ReporterMessages(t, buf)
+	require.Len(t, msgs, 5)
+
+	diff := cmp.Diff(testreporter.RelayerExecMessage{
+		Name:          "my_test",
+		StartedAt:     execStartedAt,
+		FinishedAt:    execFinishedAt,
+		ContainerName: "my_container",
+		Command:       []string{"rly", "fake_command"},
+		Stdout:        "stdout",
+		Stderr:        "stderr",
+		ExitCode:      1,
+		Error:         "",
+	}, msgs[2].(testreporter.RelayerExecMessage))
+	require.Empty(t, diff)
 }
 
 // requireTimeInRange is a helper to assert that a time occurs between a given start and end.


### PR DESCRIPTION
This was uniform to apply to all the one-off commands, but StartRelayer
and StopRelayer required a slightly different approach due to the
asynchronous style of starting the relayer in the background.

Now, container information, start and stop time, standard output and
standard error, for each relayer execution are included in the report,
so long as the ibc.Relayer implementation has implemented it.
